### PR TITLE
feat: aggiorna DoveVannoINostriSoldi con endpoint MCP remoto e aggiunge Cruscotto Italia MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"/></a>
-  <img src="https://img.shields.io/badge/server%20MCP-22-blue.svg" alt="22 server"/>
+  <img src="https://img.shields.io/badge/server%20MCP-23-blue.svg" alt="23 server"/>
   <img src="https://img.shields.io/badge/categorie-6-orange.svg" alt="6 categorie"/>
   <img src="https://img.shields.io/badge/made%20in-Italy%20%F0%9F%87%AE%F0%9F%87%B9-red.svg" alt="Made in Italy"/>
 </p>
@@ -48,7 +48,8 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 
 | Progetto | ⭐ | Lang | Descrizione |
 |----------|---:|------|-------------|
-| [**DoveVannoINostriSoldi**](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi) | 258 | TS | Spesa pubblica: SIOPE, debito, PNRR, IRPEF e altro |
+| [**DoveVannoINostriSoldi**](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi) | 258 | TS | Spesa pubblica: SIOPE, debito, PNRR, IRPEF e altro — [endpoint remoto](https://www.dovevannoinostrisoldi.com/api/mcp) |
+| [Cruscotto Italia MCP](https://cruscotto-italia-mcp.agid.workers.dev/mcp) | 0 | TS | Dati comunali per codice ISTAT: demografia, SIOPE, PNRR, sanità |
 | [**Dichiarino MCP**](https://github.com/gsaccardi/dichiarino-mcp) | 23 | Python | Assistente per la dichiarazione dei redditi |
 | [ANAC MCP](https://github.com/SimonBerg255/anac-mcp) | 4 | Python | Appalti pubblici ANAC (BDNCP) |
 | [Italian Parliament MCP](https://github.com/ondata/italianparliament-mcp) | 2 | TS | Dati del Parlamento italiano |
@@ -73,9 +74,9 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 
 | Metrica | Valore |
 |---------|--------|
-| Server totali | **22** |
+| Server totali | **23** |
 | Python | 12 |
-| TypeScript | 8 |
+| TypeScript | 9 |
 | JavaScript | 2 |
 | Licenze open source | 18 |
 | Categorie | 6 |

--- a/servers/cruscotto-italia-mcp.json
+++ b/servers/cruscotto-italia-mcp.json
@@ -1,0 +1,14 @@
+{
+  "name": "Cruscotto Italia MCP",
+  "site_url": "https://cruscotto-italia-mcp.agid.workers.dev/mcp",
+  "mcp_endpoint": "https://cruscotto-italia-mcp.agid.workers.dev/mcp",
+  "transport": "streamable-http",
+  "author": "agid",
+  "language": "TypeScript",
+  "license": "unknown",
+  "stars": 0,
+  "category": "pa-finanza-pubblica",
+  "description": "Dati comunali per codice ISTAT: demografia, SIOPE, contratti, opere, PNRR, sanità territoriale. MCP pubblico, stateless, read-only, senza autenticazione.",
+  "tools": ["search_comune", "comune_kpi", "comune_dashboard"],
+  "tags": ["comuni", "istat", "siope", "pnrr", "open-data", "remote-mcp"]
+}

--- a/servers/dovevannoinostrisoldi.json
+++ b/servers/dovevannoinostrisoldi.json
@@ -2,11 +2,14 @@
   "name": "DoveVannoINostriSoldi",
   "repository_url": "https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi",
   "site_url": "https://www.dovevannoinostrisoldi.com",
+  "mcp_endpoint": "https://www.dovevannoinostrisoldi.com/api/mcp",
+  "transport": "streamable-http",
   "author": "Italian-Builders-Org",
   "language": "TypeScript",
   "license": "AGPL-3.0",
   "stars": 258,
   "category": "pa-finanza-pubblica",
-  "description": "Progetto civico per capire come vengono usati i soldi pubblici italiani. Server MCP pubblico con dataset su spesa, debito, PNRR e altro.",
-  "tags": ["spesa-pubblica", "open-data", "civic-tech", "nextjs", "typescript"]
+  "description": "Server MCP pubblico con 31 dataset sulla spesa pubblica italiana: SIOPE, debito, PNRR, IRPEF e altro. Endpoint remoto Streamable HTTP, senza autenticazione.",
+  "tools": ["list_datasets", "query_dataset"],
+  "tags": ["spesa-pubblica", "open-data", "civic-tech", "remote-mcp", "finanza-pubblica"]
 }


### PR DESCRIPTION
## Modifiche

### DoveVannoINostriSoldi — aggiornamento
- Aggiunto **endpoint MCP remoto** Streamable HTTP: `https://www.dovevannoinostrisoldi.com/api/mcp`
- Aggiunti campi `mcp_endpoint`, `transport` e `tools` (`list_datasets`, `query_dataset`)
- Aggiornata descrizione con i 31 dataset disponibili
- Aggiornati tag con `remote-mcp` e `finanza-pubblica`

### Cruscotto Italia MCP — nuovo server
Segnalato dalla pagina di DoveVannoINostriSoldi come server MCP pubblico complementare:
- **Endpoint**: `https://cruscotto-italia-mcp.agid.workers.dev/mcp`
- **Tools**: `search_comune`, `comune_kpi`, `comune_dashboard`
- Dati comunali ricomposti per codice ISTAT: demografia, SIOPE, contratti, opere, PNRR, sanità territoriale
- MCP pubblico, stateless, read-only, senza autenticazione

### README
- Aggiunto Cruscotto Italia MCP nella tabella PA
- Aggiornati conteggi: 22 → 23 server, TypeScript 8 → 9

## Riferimento
- https://www.dovevannoinostrisoldi.com/mcp