### PR TITLE
feat: aggiunge 7 nuovi server MCP al catalogo (30 totali)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"/></a>
-  <img src="https://img.shields.io/badge/server%20MCP-23-blue.svg" alt="23 server"/>
+  <img src="https://img.shields.io/badge/server%20MCP-30-blue.svg" alt="30 server"/>
   <img src="https://img.shields.io/badge/categorie-6-orange.svg" alt="6 categorie"/>
   <img src="https://img.shields.io/badge/made%20in-Italy%20%F0%9F%87%AE%F0%9F%87%B9-red.svg" alt="Made in Italy"/>
 </p>
@@ -20,7 +20,10 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 | Progetto | ⭐ | Lang | Descrizione |
 |----------|---:|------|-------------|
 | [**ISTAT MCP Server**](https://github.com/ondata/istat_mcp_server) | 23 | Python | Statistiche ISTAT via SDMX API — il più maturo |
+| [**CKAN MCP Server**](https://github.com/ondata/ckan-mcp-server) | 57 | TS | Connettore generico per istanze CKAN (dati.gov.it e portali regionali) |
 | [ISTAT MCP](https://github.com/SimonBerg255/istat-mcp) | 3 | Python | 4700+ dataset ISTAT via SDMX, senza API key |
+| [ISTAT MCP Server (istatapi)](https://github.com/Halpph/istat-mcp-server) | 2 | Python | Dati statistici ISTAT via libreria Python istatapi |
+| [Italy OpenData MCP](https://github.com/stucchi/italy-opendata-mcp) | 1 | Python | Comuni, province, regioni, CAP, coordinate e codici ISTAT/ANPR |
 | [ISTAT MCP Suite](https://github.com/ManoloZocco/istat-mcp-suite) | 0 | Python | Server unificato per dataset ISTAT |
 | [OpenData AI](https://github.com/agent-engineering-studio/opendata-ai) | 1 | Python | Multi-source: CKAN, ISTAT, Eurostat, OECD |
 
@@ -42,6 +45,7 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 |----------|---:|------|-------------|
 | [**Fatture in Cloud MCP**](https://github.com/aringad/fattureincloud-mcp) | 18 | Python | Fatture in Cloud API con Claude AI |
 | [Aruba Fatture MCP](https://github.com/MarckDev/aruba-fatture-mcp) | 3 | TS | Aruba Fatturazione Elettronica + SDI |
+| [MCP Fattura Elettronica IT](https://github.com/cmendezs/mcp-fattura-elettronica-it) | 1 | Python | Validatore e parser XSD per tracciati XML FatturaPA/SDI |
 | [FattureInCloudMCP](https://github.com/badbat75/FattureInCloudMCP) | 0 | TS | Fatture in Cloud API v2, CRUD completo |
 
 ## 🏛️ PA, Parlamento e Finanza Pubblica
@@ -51,8 +55,10 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 | [**DoveVannoINostriSoldi**](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi) | 258 | TS | Spesa pubblica: SIOPE, debito, PNRR, IRPEF e altro — [endpoint remoto](https://www.dovevannoinostrisoldi.com/api/mcp) |
 | [Cruscotto Italia MCP](https://cruscotto-italia-mcp.agid.workers.dev/mcp) | 0 | TS | Dati comunali per codice ISTAT: demografia, SIOPE, PNRR, sanità |
 | [**Dichiarino MCP**](https://github.com/gsaccardi/dichiarino-mcp) | 23 | Python | Assistente per la dichiarazione dei redditi |
+| [Dati Semantic MCP](https://github.com/italia/dati-semantic-mcp) | 9 | TS | Catalogo semantico Developers Italia, vocabolari e ontologie PA via SPARQL |
 | [ANAC MCP](https://github.com/SimonBerg255/anac-mcp) | 4 | Python | Appalti pubblici ANAC (BDNCP) |
 | [Italian Parliament MCP](https://github.com/ondata/italianparliament-mcp) | 2 | TS | Dati del Parlamento italiano |
+| [RepublicMCP](https://github.com/giuliogarofalo/RepublicMCP) | 1 | TS | Query SPARQL sugli open data di Camera e Senato |
 
 ## 🛡️ Cybersecurity e Compliance
 
@@ -66,6 +72,7 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 | Progetto | ⭐ | Lang | Descrizione |
 |----------|---:|------|-------------|
 | [Filo — Design System Italia](https://github.com/Fupete/design-system-italia-mcp) | 3 | TS | Design system .italia (sperimentale) |
+| [INGV MCP FDSNWS Event](https://github.com/INGV/mcp-fdsnws-event) | 1 | Python | Dati sismici e eventi in tempo reale via web service INGV |
 | [MCP Meteo Italia](https://github.com/makremriahi99/MCP-Meteo-Italia) | 0 | Python | Meteo in tempo reale con FastMCP + Gradio |
 
 ---
@@ -74,11 +81,11 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 
 | Metrica | Valore |
 |---------|--------|
-| Server totali | **23** |
-| Python | 12 |
-| TypeScript | 9 |
+| Server totali | **30** |
+| Python | 16 |
+| TypeScript | 12 |
 | JavaScript | 2 |
-| Licenze open source | 18 |
+| Licenze open source | 25 |
 | Categorie | 6 |
 
 ## 🤝 Come contribuire

--- a/servers/cmendezs-mcp-fattura-elettronica-it.json
+++ b/servers/cmendezs-mcp-fattura-elettronica-it.json
@@ -1,0 +1,11 @@
+{
+  "name": "MCP Fattura Elettronica IT",
+  "repository_url": "https://github.com/cmendezs/mcp-fattura-elettronica-it",
+  "author": "cmendezs",
+  "language": "Python",
+  "license": "Apache-2.0",
+  "stars": 1,
+  "category": "fatturazione",
+  "description": "Validatore e parser XSD per tracciati XML FatturaPA/SDI (ordinaria e semplificata).",
+  "tags": ["fattura-elettronica", "fatturapa", "sdi", "xml", "xsd"]
+}

--- a/servers/giuliogarofalo-republicmcp.json
+++ b/servers/giuliogarofalo-republicmcp.json
@@ -1,0 +1,11 @@
+{
+  "name": "RepublicMCP",
+  "repository_url": "https://github.com/giuliogarofalo/RepublicMCP",
+  "author": "giuliogarofalo",
+  "language": "TypeScript",
+  "license": "MIT",
+  "stars": 1,
+  "category": "pa-finanza-pubblica",
+  "description": "Query SPARQL sugli open data ufficiali di Camera dei Deputati e Senato della Repubblica.",
+  "tags": ["parlamento", "camera", "senato", "sparql", "open-data"]
+}

--- a/servers/halpph-istat-mcp-server.json
+++ b/servers/halpph-istat-mcp-server.json
@@ -1,0 +1,11 @@
+{
+  "name": "ISTAT MCP Server (istatapi)",
+  "repository_url": "https://github.com/Halpph/istat-mcp-server",
+  "author": "Halpph",
+  "language": "Python",
+  "license": "MIT",
+  "stars": 2,
+  "category": "dati-statistiche",
+  "description": "Interfaccia MCP per i dati statistici ISTAT basata sulla libreria Python istatapi.",
+  "tags": ["istat", "istatapi", "statistiche", "open-data"]
+}

--- a/servers/ingv-mcp-fdsnws-event.json
+++ b/servers/ingv-mcp-fdsnws-event.json
@@ -1,0 +1,11 @@
+{
+  "name": "INGV MCP FDSNWS Event",
+  "repository_url": "https://github.com/INGV/mcp-fdsnws-event",
+  "author": "INGV",
+  "language": "Python",
+  "license": "AGPL-3.0",
+  "stars": 1,
+  "category": "design-altro",
+  "description": "Accesso ai dati sismici e agli eventi sismici in tempo reale tramite i web service INGV.",
+  "tags": ["ingv", "terremoti", "sismologia", "geofisica", "open-data"]
+}

--- a/servers/italia-dati-semantic-mcp.json
+++ b/servers/italia-dati-semantic-mcp.json
@@ -1,0 +1,11 @@
+{
+  "name": "Dati Semantic MCP",
+  "repository_url": "https://github.com/italia/dati-semantic-mcp",
+  "author": "italia",
+  "language": "TypeScript",
+  "license": "MIT",
+  "stars": 9,
+  "category": "pa-finanza-pubblica",
+  "description": "Server per interrogare il catalogo semantico di Developers Italia (schema.gov.it), vocabolari controllati e ontologie della PA via SPARQL.",
+  "tags": ["sparql", "ontologie", "developers-italia", "schema-gov-it", "open-data"]
+}

--- a/servers/ondata-ckan-mcp-server.json
+++ b/servers/ondata-ckan-mcp-server.json
@@ -1,0 +1,11 @@
+{
+  "name": "CKAN MCP Server",
+  "repository_url": "https://github.com/ondata/ckan-mcp-server",
+  "author": "ondata",
+  "language": "TypeScript",
+  "license": "MIT",
+  "stars": 57,
+  "category": "dati-statistiche",
+  "description": "Connettore generico per istanze CKAN, compatibile con dati.gov.it e portali regionali aperti.",
+  "tags": ["ckan", "open-data", "dati-gov-it", "portali-regionali"]
+}

--- a/servers/stucchi-italy-opendata-mcp.json
+++ b/servers/stucchi-italy-opendata-mcp.json
@@ -1,0 +1,11 @@
+{
+  "name": "Italy OpenData MCP",
+  "repository_url": "https://github.com/stucchi/italy-opendata-mcp",
+  "author": "stucchi",
+  "language": "Python",
+  "license": "MIT",
+  "stars": 1,
+  "category": "dati-statistiche",
+  "description": "Query locali su comuni, province, regioni, CAP, coordinate e codici Belfiore/catastali da fonti ISTAT e ANPR.",
+  "tags": ["comuni", "istat", "anpr", "cap", "open-data"]
+}


### PR DESCRIPTION
## Nuovi server aggiunti

| Server | Categoria | Lang | ⭐ |
|--------|-----------|------|----|
| [italia/dati-semantic-mcp](https://github.com/italia/dati-semantic-mcp) | PA | TS | 9 |
| [stucchi/italy-opendata-mcp](https://github.com/stucchi/italy-opendata-mcp) | Dati | Python | 1 |
| [ondata/ckan-mcp-server](https://github.com/ondata/ckan-mcp-server) | Dati | TS | 57 |
| [Halpph/istat-mcp-server](https://github.com/Halpph/istat-mcp-server) | Dati | Python | 2 |
| [cmendezs/mcp-fattura-elettronica-it](https://github.com/cmendezs/mcp-fattura-elettronica-it) | Fatturazione | Python | 1 |
| [giuliogarofalo/RepublicMCP](https://github.com/giuliogarofalo/RepublicMCP) | PA | TS | 1 |
| [INGV/mcp-fdsnws-event](https://github.com/INGV/mcp-fdsnws-event) | Design/Altro | Python | 1 |

## Modifiche

- 7 nuovi file JSON in `servers/`
- README aggiornato: 23 → **30** server, Python 12→16, TypeScript 9→12, licenze 18→25