### PR TITLE
feat: genera le sezioni del README dai file in servers/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,12 @@
 1. **Fai un fork** del repository
 2. Crea un file JSON in `servers/` con nome in `kebab-case.json`
 3. Compila tutti i campi richiesti (vedi schema nel README)
-4. Apri una Pull Request con titolo: `feat: added Nome Server`
+4. Rigenera il README con `python3 scripts/build_readme.py` e includi il file aggiornato nel commit
+5. Apri una Pull Request con titolo: `feat: added Nome Server`
+
+> Le tabelle del catalogo, i badge e le statistiche nel README sono generati
+> automaticamente dai file in `servers/`: non modificarli a mano, altrimenti le
+> modifiche vengono sovrascritte alla rigenerazione successiva.
 
 ## Criteri
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 </p>
 
 <p align="center">
+<!-- BEGIN:badges -->
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"/></a>
   <img src="https://img.shields.io/badge/server%20MCP-30-blue.svg" alt="30 server"/>
   <img src="https://img.shields.io/badge/categorie-6-orange.svg" alt="6 categorie"/>
   <img src="https://img.shields.io/badge/made%20in-Italy%20%F0%9F%87%AE%F0%9F%87%B9-red.svg" alt="Made in Italy"/>
+<!-- END:badges -->
 </p>
 
 ---
@@ -15,17 +17,18 @@
 
 Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code Copilot...) di collegarsi a fonti dati e strumenti esterni in modo standardizzato. Questo catalogo raccoglie tutti i server MCP sviluppati per il contesto italiano.
 
+<!-- BEGIN:catalog -->
 ## 📊 Dati e Statistiche
 
 | Progetto | ⭐ | Lang | Descrizione |
 |----------|---:|------|-------------|
-| [**ISTAT MCP Server**](https://github.com/ondata/istat_mcp_server) | 23 | Python | Statistiche ISTAT via SDMX API — il più maturo |
 | [**CKAN MCP Server**](https://github.com/ondata/ckan-mcp-server) | 57 | TS | Connettore generico per istanze CKAN (dati.gov.it e portali regionali) |
+| [**ISTAT MCP Server**](https://github.com/ondata/istat_mcp_server) | 23 | Python | Statistiche ISTAT via SDMX API — il più maturo |
 | [ISTAT MCP](https://github.com/SimonBerg255/istat-mcp) | 3 | Python | 4700+ dataset ISTAT via SDMX, senza API key |
 | [ISTAT MCP Server (istatapi)](https://github.com/Halpph/istat-mcp-server) | 2 | Python | Dati statistici ISTAT via libreria Python istatapi |
 | [Italy OpenData MCP](https://github.com/stucchi/italy-opendata-mcp) | 1 | Python | Comuni, province, regioni, CAP, coordinate e codici ISTAT/ANPR |
-| [ISTAT MCP Suite](https://github.com/ManoloZocco/istat-mcp-suite) | 0 | Python | Server unificato per dataset ISTAT |
 | [OpenData AI](https://github.com/agent-engineering-studio/opendata-ai) | 1 | Python | Multi-source: CKAN, ISTAT, Eurostat, OECD |
+| [ISTAT MCP Suite](https://github.com/ManoloZocco/istat-mcp-suite) | 0 | Python | Server unificato per dataset ISTAT |
 
 ## ⚖️ Legal-Tech e Normativa
 
@@ -53,19 +56,19 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 | Progetto | ⭐ | Lang | Descrizione |
 |----------|---:|------|-------------|
 | [**DoveVannoINostriSoldi**](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi) | 258 | TS | Spesa pubblica: SIOPE, debito, PNRR, IRPEF e altro — [endpoint remoto](https://www.dovevannoinostrisoldi.com/api/mcp) |
-| [Cruscotto Italia MCP](https://cruscotto-italia-mcp.agid.workers.dev/mcp) | 0 | TS | Dati comunali per codice ISTAT: demografia, SIOPE, PNRR, sanità |
 | [**Dichiarino MCP**](https://github.com/gsaccardi/dichiarino-mcp) | 23 | Python | Assistente per la dichiarazione dei redditi |
 | [Dati Semantic MCP](https://github.com/italia/dati-semantic-mcp) | 9 | TS | Catalogo semantico Developers Italia, vocabolari e ontologie PA via SPARQL |
 | [ANAC MCP](https://github.com/SimonBerg255/anac-mcp) | 4 | Python | Appalti pubblici ANAC (BDNCP) |
 | [Italian Parliament MCP](https://github.com/ondata/italianparliament-mcp) | 2 | TS | Dati del Parlamento italiano |
 | [RepublicMCP](https://github.com/giuliogarofalo/RepublicMCP) | 1 | TS | Query SPARQL sugli open data di Camera e Senato |
+| [Cruscotto Italia MCP](https://cruscotto-italia-mcp.agid.workers.dev/mcp) | 0 | TS | Dati comunali per codice ISTAT: demografia, SIOPE, PNRR, sanità |
 
 ## 🛡️ Cybersecurity e Compliance
 
 | Progetto | ⭐ | Lang | Descrizione |
 |----------|---:|------|-------------|
-| [Italian Cybersecurity MCP](https://github.com/Ansvar-Systems/italian-cybersecurity-mcp) | 0 | TS | ACN — linee guida e advisory |
 | [Italian Competition MCP](https://github.com/Ansvar-Systems/italian-competition-mcp) | 0 | TS | AGCM — decisioni antitrust |
+| [Italian Cybersecurity MCP](https://github.com/Ansvar-Systems/italian-cybersecurity-mcp) | 0 | TS | ACN — linee guida e advisory |
 
 ## 🎨 Design e Altro
 
@@ -74,19 +77,22 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 | [Filo — Design System Italia](https://github.com/Fupete/design-system-italia-mcp) | 3 | TS | Design system .italia (sperimentale) |
 | [INGV MCP FDSNWS Event](https://github.com/INGV/mcp-fdsnws-event) | 1 | Python | Dati sismici e eventi in tempo reale via web service INGV |
 | [MCP Meteo Italia](https://github.com/makremriahi99/MCP-Meteo-Italia) | 0 | Python | Meteo in tempo reale con FastMCP + Gradio |
+<!-- END:catalog -->
 
 ---
 
 ## 📈 Statistiche
 
+<!-- BEGIN:stats -->
 | Metrica | Valore |
 |---------|--------|
 | Server totali | **30** |
 | Python | 16 |
-| TypeScript | 12 |
-| JavaScript | 2 |
-| Licenze open source | 25 |
+| TypeScript | 13 |
+| JavaScript | 1 |
+| Licenze open source | 22 |
 | Categorie | 6 |
+<!-- END:stats -->
 
 ## 🤝 Come contribuire
 
@@ -100,18 +106,35 @@ Conosci un server MCP italiano non presente in questo catalogo? Apri una PR!
   "name": "Nome del Server",
   "repository_url": "https://github.com/owner/repo",
   "site_url": "https://...",
+  "mcp_endpoint": "https://.../mcp",
   "author": "owner",
   "language": "Python",
   "license": "MIT",
   "stars": 0,
   "category": "dati-statistiche",
+  "short_description": "Descrizione compatta per la tabella del catalogo.",
   "description": "Breve descrizione del server (max 200 caratteri).",
   "tags": ["tag1", "tag2", "tag3"]
 }
 ```
 
+I campi `site_url`, `mcp_endpoint`, `short_description` e `featured` sono opzionali:
+`short_description` sostituisce `description` nelle tabelle del catalogo,
+`mcp_endpoint` aggiunge il link all'endpoint remoto e `featured: true` mette il
+progetto in evidenza in cima alla sua categoria.
+
+3. **Rigenera il README** — le tabelle, i badge e le statistiche sono generati dai
+   file in `servers/` e non vanno modificati a mano:
+
+```bash
+python3 scripts/build_readme.py
+```
+
+La CI verifica l'allineamento con `python3 scripts/build_readme.py --check`.
+
 ### Categorie ammesse
 
+<!-- BEGIN:categories -->
 | Categoria | Descrizione |
 |-----------|-------------|
 | `dati-statistiche` | ISTAT, Eurostat, open data |
@@ -120,6 +143,7 @@ Conosci un server MCP italiano non presente in questo catalogo? Apri una PR!
 | `pa-finanza-pubblica` | PA, parlamento, fisco, appalti |
 | `cybersecurity-compliance` | ACN, AGCM, compliance |
 | `design-altro` | Design system, meteo, altro |
+<!-- END:categories -->
 
 ### Criteri di inclusione
 

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Rigenera le sezioni dinamiche del README a partire dai file in servers/.
+
+Uso:
+    python3 scripts/build_readme.py            # riscrive il README
+    python3 scripts/build_readme.py --check    # esce con 1 se il README non e' aggiornato
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SERVERS_DIR = ROOT / "servers"
+README = ROOT / "README.md"
+
+# Ordine, intestazione e descrizione delle categorie ammesse.
+CATEGORIES = [
+    ("dati-statistiche", "📊 Dati e Statistiche", "ISTAT, Eurostat, open data"),
+    ("legal-tech", "⚖️ Legal-Tech e Normativa", "Normativa, giurisprudenza, privacy"),
+    ("fatturazione", "🧾 Fatturazione Elettronica", "Fatture elettroniche, SDI"),
+    ("pa-finanza-pubblica", "🏛️ PA, Parlamento e Finanza Pubblica", "PA, parlamento, fisco, appalti"),
+    ("cybersecurity-compliance", "🛡️ Cybersecurity e Compliance", "ACN, AGCM, compliance"),
+    ("design-altro", "🎨 Design e Altro", "Design system, meteo, altro"),
+]
+
+# Abbreviazioni usate nella colonna "Lang" del catalogo.
+LANGUAGE_ABBR = {"TypeScript": "TS", "JavaScript": "JS"}
+
+# Valori di `license` che non identificano una licenza open source riconosciuta.
+NON_OSS_LICENSES = {"n/a", "unknown", "noassertion", ""}
+
+BLOCK_RE_TEMPLATE = r"(<!-- BEGIN:{name} -->\n)(?:.*?)(\n<!-- END:{name} -->)"
+
+
+def load_servers() -> list[dict]:
+    servers = []
+    for path in sorted(SERVERS_DIR.glob("*.json")):
+        with path.open(encoding="utf-8") as fh:
+            try:
+                data = json.load(fh)
+            except json.JSONDecodeError as exc:
+                sys.exit(f"{path}: JSON non valido: {exc}")
+        data["_path"] = path
+        servers.append(data)
+    if not servers:
+        sys.exit(f"{SERVERS_DIR}: nessun server trovato")
+    return servers
+
+
+def primary_url(server: dict) -> str:
+    for key in ("repository_url", "site_url", "mcp_endpoint"):
+        url = server.get(key)
+        if url:
+            return url
+    sys.exit(f"{server['_path']}: manca un URL (repository_url, site_url o mcp_endpoint)")
+
+
+def sort_key(server: dict):
+    return (not server.get("featured", False), -server.get("stars", 0), server["name"].lower())
+
+
+def escape_cell(text: str) -> str:
+    return text.replace("|", "\\|")
+
+
+def render_row(server: dict) -> str:
+    name = escape_cell(server["name"])
+    label = f"**{name}**" if server.get("featured") else name
+    url = primary_url(server)
+    description = escape_cell(server.get("short_description") or server["description"])
+
+    endpoint = server.get("mcp_endpoint")
+    if endpoint and endpoint != url:
+        description += f" — [endpoint remoto]({endpoint})"
+
+    language = server.get("language", "—")
+    return (
+        f"| [{label}]({url}) | {server.get('stars', 0)} | "
+        f"{escape_cell(LANGUAGE_ABBR.get(language, language))} | {description} |"
+    )
+
+
+def render_catalog(servers: list[dict]) -> str:
+    known = {slug for slug, _, _ in CATEGORIES}
+    for server in servers:
+        if server.get("category") not in known:
+            sys.exit(f"{server['_path']}: categoria sconosciuta {server.get('category')!r}")
+
+    sections = []
+    for slug, title, _ in CATEGORIES:
+        rows = sorted((s for s in servers if s["category"] == slug), key=sort_key)
+        if not rows:
+            continue
+        body = "\n".join(render_row(server) for server in rows)
+        sections.append(
+            f"## {title}\n\n"
+            "| Progetto | ⭐ | Lang | Descrizione |\n"
+            "|----------|---:|------|-------------|\n"
+            f"{body}"
+        )
+    return "\n\n".join(sections)
+
+
+def render_stats(servers: list[dict]) -> str:
+    languages: dict[str, int] = {}
+    for server in servers:
+        language = server.get("language", "—")
+        languages[language] = languages.get(language, 0) + 1
+
+    oss = sum(
+        1
+        for server in servers
+        if str(server.get("license") or "").strip().lower() not in NON_OSS_LICENSES
+    )
+
+    lines = [
+        "| Metrica | Valore |",
+        "|---------|--------|",
+        f"| Server totali | **{len(servers)}** |",
+    ]
+    for language, count in sorted(languages.items(), key=lambda kv: (-kv[1], kv[0])):
+        lines.append(f"| {language} | {count} |")
+    lines.append(f"| Licenze open source | {oss} |")
+    lines.append(f"| Categorie | {len({s['category'] for s in servers})} |")
+    return "\n".join(lines)
+
+
+def render_badges(servers: list[dict]) -> str:
+    categories = len({s["category"] for s in servers})
+    return (
+        '  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" '
+        'alt="MIT License"/></a>\n'
+        f'  <img src="https://img.shields.io/badge/server%20MCP-{len(servers)}-blue.svg" '
+        f'alt="{len(servers)} server"/>\n'
+        f'  <img src="https://img.shields.io/badge/categorie-{categories}-orange.svg" '
+        f'alt="{categories} categorie"/>\n'
+        '  <img src="https://img.shields.io/badge/made%20in-Italy%20%F0%9F%87%AE%F0%9F%87%B9-red.svg" '
+        'alt="Made in Italy"/>'
+    )
+
+
+def render_category_table() -> str:
+    lines = ["| Categoria | Descrizione |", "|-----------|-------------|"]
+    for slug, _, description in CATEGORIES:
+        lines.append(f"| `{slug}` | {description} |")
+    return "\n".join(lines)
+
+
+def replace_block(content: str, name: str, body: str) -> str:
+    pattern = re.compile(BLOCK_RE_TEMPLATE.format(name=re.escape(name)), re.S)
+    if not pattern.search(content):
+        sys.exit(f"README.md: marker <!-- BEGIN:{name} --> / <!-- END:{name} --> non trovato")
+    # Il body e' inserito tramite lambda per evitare che \g, \1 ecc. vengano interpretati.
+    return pattern.sub(lambda m: m.group(1) + body + m.group(2), content)
+
+
+def build(content: str, servers: list[dict]) -> str:
+    content = replace_block(content, "badges", render_badges(servers))
+    content = replace_block(content, "catalog", render_catalog(servers))
+    content = replace_block(content, "stats", render_stats(servers))
+    content = replace_block(content, "categories", render_category_table())
+    return content
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verifica che il README sia allineato ai file in servers/ senza riscriverlo",
+    )
+    args = parser.parse_args()
+
+    servers = load_servers()
+    current = README.read_text(encoding="utf-8")
+    updated = build(current, servers)
+
+    if args.check:
+        if current != updated:
+            print(
+                "README.md non è aggiornato. Esegui: python3 scripts/build_readme.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"README.md allineato ({len(servers)} server).")
+        return 0
+
+    if current == updated:
+        print(f"README.md già aggiornato ({len(servers)} server).")
+        return 0
+
+    README.write_text(updated, encoding="utf-8")
+    print(f"README.md rigenerato ({len(servers)} server).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/servers/adellorto-normattiva-mcp.json
+++ b/servers/adellorto-normattiva-mcp.json
@@ -6,6 +6,11 @@
   "license": "MIT",
   "stars": 1,
   "category": "legal-tech",
+  "short_description": "API di Normattiva",
   "description": "Server MCP per le API di Normattiva — legislazione italiana.",
-  "tags": ["normattiva", "legislazione", "python"]
+  "tags": [
+    "normattiva",
+    "legislazione",
+    "python"
+  ]
 }

--- a/servers/ansvar-italian-competition-mcp.json
+++ b/servers/ansvar-italian-competition-mcp.json
@@ -6,6 +6,12 @@
   "license": "Apache-2.0",
   "stars": 0,
   "category": "cybersecurity-compliance",
+  "short_description": "AGCM — decisioni antitrust",
   "description": "Server MCP per le decisioni dell'AGCM (Autorità Garante della Concorrenza e del Mercato).",
-  "tags": ["agcm", "antitrust", "concorrenza", "typescript"]
+  "tags": [
+    "agcm",
+    "antitrust",
+    "concorrenza",
+    "typescript"
+  ]
 }

--- a/servers/ansvar-italian-cybersecurity-mcp.json
+++ b/servers/ansvar-italian-cybersecurity-mcp.json
@@ -6,6 +6,12 @@
   "license": "Apache-2.0",
   "stars": 0,
   "category": "cybersecurity-compliance",
+  "short_description": "ACN — linee guida e advisory",
   "description": "Server MCP per le linee guida e gli advisory dell'ACN (Agenzia per la Cybersicurezza Nazionale).",
-  "tags": ["acn", "cybersecurity", "advisory", "typescript"]
+  "tags": [
+    "acn",
+    "cybersecurity",
+    "advisory",
+    "typescript"
+  ]
 }

--- a/servers/ansvar-italian-law-mcp.json
+++ b/servers/ansvar-italian-law-mcp.json
@@ -6,6 +6,12 @@
   "license": "Apache-2.0",
   "stars": 1,
   "category": "legal-tech",
+  "short_description": "GDPR, Codice Privacy, cybercrime",
   "description": "Database legislativo italiano: protezione dati (GDPR/Codice Privacy), cybercrime (Codice Penale), compliance.",
-  "tags": ["gdpr", "privacy", "codice-penale", "typescript"]
+  "tags": [
+    "gdpr",
+    "privacy",
+    "codice-penale",
+    "typescript"
+  ]
 }

--- a/servers/aringad-fattureincloud-mcp.json
+++ b/servers/aringad-fattureincloud-mcp.json
@@ -6,6 +6,13 @@
   "license": "MIT",
   "stars": 18,
   "category": "fatturazione",
+  "featured": true,
+  "short_description": "Fatture in Cloud API con Claude AI",
   "description": "Server MCP per le API Fatture in Cloud — gestione fatture elettroniche italiane con Claude AI.",
-  "tags": ["fatturazione", "fatture-in-cloud", "sdi", "python"]
+  "tags": [
+    "fatturazione",
+    "fatture-in-cloud",
+    "sdi",
+    "python"
+  ]
 }

--- a/servers/avvocati-e-mac-anonymcp.json
+++ b/servers/avvocati-e-mac-anonymcp.json
@@ -6,6 +6,12 @@
   "license": "AGPL-3.0",
   "stars": 5,
   "category": "legal-tech",
+  "short_description": "Pseudonimizza documenti legali prima dell'LLM",
   "description": "Server MCP locale che pseudonimizza documenti legali italiani prima di esporli a un LLM (privacy by design).",
-  "tags": ["privacy", "pseudonimizzazione", "legale", "typescript"]
+  "tags": [
+    "privacy",
+    "pseudonimizzazione",
+    "legale",
+    "typescript"
+  ]
 }

--- a/servers/avvocati-e-mac-normattiva-mcp.json
+++ b/servers/avvocati-e-mac-normattiva-mcp.json
@@ -6,6 +6,12 @@
   "license": "NOASSERTION",
   "stars": 0,
   "category": "legal-tech",
+  "short_description": "CLI + MCP per citare norme da Normattiva.it",
   "description": "CLI e server MCP per leggere, verificare e citare norme italiane da Normattiva.it.",
-  "tags": ["normattiva", "cli", "citazioni", "python"]
+  "tags": [
+    "normattiva",
+    "cli",
+    "citazioni",
+    "python"
+  ]
 }

--- a/servers/badbat75-fattureincloudmcp.json
+++ b/servers/badbat75-fattureincloudmcp.json
@@ -6,6 +6,11 @@
   "license": "n/a",
   "stars": 0,
   "category": "fatturazione",
+  "short_description": "Fatture in Cloud API v2, CRUD completo",
   "description": "Server MCP (stdio, TypeScript SDK) per le API Fatture in Cloud v2: CRUD su documenti emessi/ricevuti.",
-  "tags": ["fatturazione", "fatture-in-cloud", "typescript"]
+  "tags": [
+    "fatturazione",
+    "fatture-in-cloud",
+    "typescript"
+  ]
 }

--- a/servers/bettercallclaude-italia.json
+++ b/servers/bettercallclaude-italia.json
@@ -6,6 +6,13 @@
   "license": "AGPL-3.0",
   "stars": 44,
   "category": "legal-tech",
+  "featured": true,
+  "short_description": "Quadro normativo italiano completo",
   "description": "BetterCallClaude per il quadro normativo italiano, con MCP dedicati esclusivamente al diritto italiano.",
-  "tags": ["diritto", "normativa", "legale", "javascript"]
+  "tags": [
+    "diritto",
+    "normativa",
+    "legale",
+    "javascript"
+  ]
 }

--- a/servers/capazme-mcp-legal-it.json
+++ b/servers/capazme-mcp-legal-it.json
@@ -6,6 +6,13 @@
   "license": "Apache-2.0",
   "stars": 14,
   "category": "legal-tech",
+  "featured": true,
+  "short_description": "200+ tool: statuti, giurisprudenza, calcoli legali",
   "description": "Server MCP + plugin Claude per il diritto italiano — 200+ tool: statuti verificati, ricerca giurisprudenza, calcoli legali.",
-  "tags": ["diritto", "giurisprudenza", "legale", "python"]
+  "tags": [
+    "diritto",
+    "giurisprudenza",
+    "legale",
+    "python"
+  ]
 }

--- a/servers/cmendezs-mcp-fattura-elettronica-it.json
+++ b/servers/cmendezs-mcp-fattura-elettronica-it.json
@@ -6,6 +6,13 @@
   "license": "Apache-2.0",
   "stars": 1,
   "category": "fatturazione",
+  "short_description": "Validatore e parser XSD per tracciati XML FatturaPA/SDI",
   "description": "Validatore e parser XSD per tracciati XML FatturaPA/SDI (ordinaria e semplificata).",
-  "tags": ["fattura-elettronica", "fatturapa", "sdi", "xml", "xsd"]
+  "tags": [
+    "fattura-elettronica",
+    "fatturapa",
+    "sdi",
+    "xml",
+    "xsd"
+  ]
 }

--- a/servers/cruscotto-italia-mcp.json
+++ b/servers/cruscotto-italia-mcp.json
@@ -8,7 +8,19 @@
   "license": "unknown",
   "stars": 0,
   "category": "pa-finanza-pubblica",
+  "short_description": "Dati comunali per codice ISTAT: demografia, SIOPE, PNRR, sanità",
   "description": "Dati comunali per codice ISTAT: demografia, SIOPE, contratti, opere, PNRR, sanità territoriale. MCP pubblico, stateless, read-only, senza autenticazione.",
-  "tools": ["search_comune", "comune_kpi", "comune_dashboard"],
-  "tags": ["comuni", "istat", "siope", "pnrr", "open-data", "remote-mcp"]
+  "tags": [
+    "comuni",
+    "istat",
+    "siope",
+    "pnrr",
+    "open-data",
+    "remote-mcp"
+  ],
+  "tools": [
+    "search_comune",
+    "comune_kpi",
+    "comune_dashboard"
+  ]
 }

--- a/servers/dovevannoinostrisoldi.json
+++ b/servers/dovevannoinostrisoldi.json
@@ -9,7 +9,18 @@
   "license": "AGPL-3.0",
   "stars": 258,
   "category": "pa-finanza-pubblica",
+  "featured": true,
+  "short_description": "Spesa pubblica: SIOPE, debito, PNRR, IRPEF e altro",
   "description": "Server MCP pubblico con 31 dataset sulla spesa pubblica italiana: SIOPE, debito, PNRR, IRPEF e altro. Endpoint remoto Streamable HTTP, senza autenticazione.",
-  "tools": ["list_datasets", "query_dataset"],
-  "tags": ["spesa-pubblica", "open-data", "civic-tech", "remote-mcp", "finanza-pubblica"]
+  "tags": [
+    "spesa-pubblica",
+    "open-data",
+    "civic-tech",
+    "remote-mcp",
+    "finanza-pubblica"
+  ],
+  "tools": [
+    "list_datasets",
+    "query_dataset"
+  ]
 }

--- a/servers/fupete-design-system-italia-mcp.json
+++ b/servers/fupete-design-system-italia-mcp.json
@@ -1,11 +1,17 @@
 {
-  "name": "Filo - Design System Italia MCP",
+  "name": "Filo — Design System Italia",
   "repository_url": "https://github.com/Fupete/design-system-italia-mcp",
   "author": "Fupete",
   "language": "TypeScript",
   "license": "BSD-3-Clause",
   "stars": 3,
   "category": "design-altro",
+  "short_description": "Design system .italia (sperimentale)",
   "description": "Server MCP sperimentale e non ufficiale per il Design system .italia.",
-  "tags": ["design-system", "pa", "ui", "typescript"]
+  "tags": [
+    "design-system",
+    "pa",
+    "ui",
+    "typescript"
+  ]
 }

--- a/servers/giuliogarofalo-republicmcp.json
+++ b/servers/giuliogarofalo-republicmcp.json
@@ -6,6 +6,13 @@
   "license": "MIT",
   "stars": 1,
   "category": "pa-finanza-pubblica",
+  "short_description": "Query SPARQL sugli open data di Camera e Senato",
   "description": "Query SPARQL sugli open data ufficiali di Camera dei Deputati e Senato della Repubblica.",
-  "tags": ["parlamento", "camera", "senato", "sparql", "open-data"]
+  "tags": [
+    "parlamento",
+    "camera",
+    "senato",
+    "sparql",
+    "open-data"
+  ]
 }

--- a/servers/gov-it-legal-mcp.json
+++ b/servers/gov-it-legal-mcp.json
@@ -6,6 +6,12 @@
   "license": "MIT",
   "stars": 10,
   "category": "legal-tech",
+  "short_description": "Normattiva + sentenze TAR/CdS",
   "description": "Server MCP per la legislazione italiana (Normattiva) e le sentenze dei tribunali amministrativi (TAR/CdS).",
-  "tags": ["normattiva", "tar", "legislazione", "python"]
+  "tags": [
+    "normattiva",
+    "tar",
+    "legislazione",
+    "python"
+  ]
 }

--- a/servers/gsaccardi-dichiarino-mcp.json
+++ b/servers/gsaccardi-dichiarino-mcp.json
@@ -6,6 +6,12 @@
   "license": "NOASSERTION",
   "stars": 23,
   "category": "pa-finanza-pubblica",
+  "featured": true,
+  "short_description": "Assistente per la dichiarazione dei redditi",
   "description": "Assistente MCP intelligente per la compilazione della dichiarazione dei redditi italiana.",
-  "tags": ["dichiarazione-redditi", "fisco", "python"]
+  "tags": [
+    "dichiarazione-redditi",
+    "fisco",
+    "python"
+  ]
 }

--- a/servers/halpph-istat-mcp-server.json
+++ b/servers/halpph-istat-mcp-server.json
@@ -6,6 +6,12 @@
   "license": "MIT",
   "stars": 2,
   "category": "dati-statistiche",
+  "short_description": "Dati statistici ISTAT via libreria Python istatapi",
   "description": "Interfaccia MCP per i dati statistici ISTAT basata sulla libreria Python istatapi.",
-  "tags": ["istat", "istatapi", "statistiche", "open-data"]
+  "tags": [
+    "istat",
+    "istatapi",
+    "statistiche",
+    "open-data"
+  ]
 }

--- a/servers/ingv-mcp-fdsnws-event.json
+++ b/servers/ingv-mcp-fdsnws-event.json
@@ -6,6 +6,13 @@
   "license": "AGPL-3.0",
   "stars": 1,
   "category": "design-altro",
+  "short_description": "Dati sismici e eventi in tempo reale via web service INGV",
   "description": "Accesso ai dati sismici e agli eventi sismici in tempo reale tramite i web service INGV.",
-  "tags": ["ingv", "terremoti", "sismologia", "geofisica", "open-data"]
+  "tags": [
+    "ingv",
+    "terremoti",
+    "sismologia",
+    "geofisica",
+    "open-data"
+  ]
 }

--- a/servers/italia-dati-semantic-mcp.json
+++ b/servers/italia-dati-semantic-mcp.json
@@ -6,6 +6,13 @@
   "license": "MIT",
   "stars": 9,
   "category": "pa-finanza-pubblica",
+  "short_description": "Catalogo semantico Developers Italia, vocabolari e ontologie PA via SPARQL",
   "description": "Server per interrogare il catalogo semantico di Developers Italia (schema.gov.it), vocabolari controllati e ontologie della PA via SPARQL.",
-  "tags": ["sparql", "ontologie", "developers-italia", "schema-gov-it", "open-data"]
+  "tags": [
+    "sparql",
+    "ontologie",
+    "developers-italia",
+    "schema-gov-it",
+    "open-data"
+  ]
 }

--- a/servers/makremriahi99-mcp-meteo-italia.json
+++ b/servers/makremriahi99-mcp-meteo-italia.json
@@ -6,6 +6,12 @@
   "license": "n/a",
   "stars": 0,
   "category": "design-altro",
+  "short_description": "Meteo in tempo reale con FastMCP + Gradio",
   "description": "Server MCP per dati meteo italiani in tempo reale — FastMCP + Gradio, integrabile con Claude.",
-  "tags": ["meteo", "tempo-reale", "gradio", "python"]
+  "tags": [
+    "meteo",
+    "tempo-reale",
+    "gradio",
+    "python"
+  ]
 }

--- a/servers/manolozocco-istat-mcp-suite.json
+++ b/servers/manolozocco-istat-mcp-suite.json
@@ -6,6 +6,11 @@
   "license": "n/a",
   "stars": 0,
   "category": "dati-statistiche",
+  "short_description": "Server unificato per dataset ISTAT",
   "description": "Server MCP unificato per interrogare e scaricare dataset ISTAT via SDMX REST API.",
-  "tags": ["istat", "sdmx", "python"]
+  "tags": [
+    "istat",
+    "sdmx",
+    "python"
+  ]
 }

--- a/servers/marckdev-aruba-fatture-mcp.json
+++ b/servers/marckdev-aruba-fatture-mcp.json
@@ -6,6 +6,12 @@
   "license": "n/a",
   "stars": 3,
   "category": "fatturazione",
+  "short_description": "Aruba Fatturazione Elettronica + SDI",
   "description": "Server MCP per Aruba Fatturazione Elettronica — invia, cerca e traccia le fatture SDI.",
-  "tags": ["fatturazione", "aruba", "sdi", "typescript"]
+  "tags": [
+    "fatturazione",
+    "aruba",
+    "sdi",
+    "typescript"
+  ]
 }

--- a/servers/ondata-ckan-mcp-server.json
+++ b/servers/ondata-ckan-mcp-server.json
@@ -6,6 +6,13 @@
   "license": "MIT",
   "stars": 57,
   "category": "dati-statistiche",
+  "featured": true,
+  "short_description": "Connettore generico per istanze CKAN (dati.gov.it e portali regionali)",
   "description": "Connettore generico per istanze CKAN, compatibile con dati.gov.it e portali regionali aperti.",
-  "tags": ["ckan", "open-data", "dati-gov-it", "portali-regionali"]
+  "tags": [
+    "ckan",
+    "open-data",
+    "dati-gov-it",
+    "portali-regionali"
+  ]
 }

--- a/servers/ondata-istat-mcp-server.json
+++ b/servers/ondata-istat-mcp-server.json
@@ -6,6 +6,14 @@
   "license": "MIT",
   "stars": 23,
   "category": "dati-statistiche",
+  "featured": true,
+  "short_description": "Statistiche ISTAT via SDMX API — il più maturo",
   "description": "Server MCP per interrogare le statistiche italiane ISTAT via SDMX API. Compatibile con qualsiasi client MCP.",
-  "tags": ["istat", "sdmx", "statistiche", "open-data", "python"]
+  "tags": [
+    "istat",
+    "sdmx",
+    "statistiche",
+    "open-data",
+    "python"
+  ]
 }

--- a/servers/ondata-italianparliament-mcp.json
+++ b/servers/ondata-italianparliament-mcp.json
@@ -6,6 +6,12 @@
   "license": "MIT",
   "stars": 2,
   "category": "pa-finanza-pubblica",
+  "short_description": "Dati del Parlamento italiano",
   "description": "Server MCP per i dati del Parlamento italiano.",
-  "tags": ["parlamento", "camera", "senato", "typescript"]
+  "tags": [
+    "parlamento",
+    "camera",
+    "senato",
+    "typescript"
+  ]
 }

--- a/servers/opendata-ai.json
+++ b/servers/opendata-ai.json
@@ -6,6 +6,13 @@
   "license": "MIT",
   "stars": 1,
   "category": "dati-statistiche",
+  "short_description": "Multi-source: CKAN, ISTAT, Eurostat, OECD",
   "description": "AI conversazionale multi-source per open data italiani ed europei — CKAN, ISTAT, Eurostat, OECD.",
-  "tags": ["open-data", "istat", "eurostat", "ckan", "python"]
+  "tags": [
+    "open-data",
+    "istat",
+    "eurostat",
+    "ckan",
+    "python"
+  ]
 }

--- a/servers/simonberg255-anac-mcp.json
+++ b/servers/simonberg255-anac-mcp.json
@@ -6,6 +6,12 @@
   "license": "n/a",
   "stars": 4,
   "category": "pa-finanza-pubblica",
+  "short_description": "Appalti pubblici ANAC (BDNCP)",
   "description": "ANAC Procurement Intelligence — dati sugli appalti pubblici italiani (BDNCP), senza credenziali.",
-  "tags": ["anac", "appalti", "procurement", "python"]
+  "tags": [
+    "anac",
+    "appalti",
+    "procurement",
+    "python"
+  ]
 }

--- a/servers/simonberg255-istat-mcp.json
+++ b/servers/simonberg255-istat-mcp.json
@@ -6,6 +6,12 @@
   "license": "MIT",
   "stars": 3,
   "category": "dati-statistiche",
+  "short_description": "4700+ dataset ISTAT via SDMX, senza API key",
   "description": "Server MCP per statistiche ISTAT — 4700+ dataset via SDMX REST API, senza API key.",
-  "tags": ["istat", "sdmx", "statistiche", "python"]
+  "tags": [
+    "istat",
+    "sdmx",
+    "statistiche",
+    "python"
+  ]
 }

--- a/servers/stucchi-italy-opendata-mcp.json
+++ b/servers/stucchi-italy-opendata-mcp.json
@@ -6,6 +6,13 @@
   "license": "MIT",
   "stars": 1,
   "category": "dati-statistiche",
+  "short_description": "Comuni, province, regioni, CAP, coordinate e codici ISTAT/ANPR",
   "description": "Query locali su comuni, province, regioni, CAP, coordinate e codici Belfiore/catastali da fonti ISTAT e ANPR.",
-  "tags": ["comuni", "istat", "anpr", "cap", "open-data"]
+  "tags": [
+    "comuni",
+    "istat",
+    "anpr",
+    "cap",
+    "open-data"
+  ]
 }


### PR DESCRIPTION
## Problema

Le tabelle del catalogo, i badge e le statistiche del README erano mantenuti a mano in parallelo ai file in `servers/`. I due lati avevano già iniziato a divergere:

| Metrica | README | Reale |
|---|---|---|
| TypeScript | 12 | **13** |
| JavaScript | 2 | **1** |
| Licenze open source | 25 | **22** |

Ogni PR che aggiunge un server richiedeva quattro modifiche coordinate (JSON, tabella di categoria, badge, statistiche), quindi il drift era destinato a peggiorare.

## Soluzione

`scripts/build_readme.py` rigenera i blocchi del README delimitati da marker a partire dai JSON in `servers/`. Solo stdlib, nessuna dipendenza.

```bash
python3 scripts/build_readme.py          # rigenera
python3 scripts/build_readme.py --check  # exit 1 se disallineato (per la CI)
```

Blocchi generati: `<!-- BEGIN:badges -->`, `catalog`, `stats`, `categories`. Tutto il testo fuori dai marker resta editabile a mano.

## Modifiche ai dati

Due campi opzionali, entrambi estratti dal README attuale per non perdere nulla:

- `short_description` — testo compatto usato nelle tabelle del catalogo, con fallback su `description`
- `featured: true` — mette il progetto in evidenza (in grassetto, in cima alla sua categoria)

Inoltre: chiavi dei JSON riordinate in modo canonico, e fallback dell'URL su `site_url` / `mcp_endpoint` per i server senza `repository_url` (`cruscotto-italia-mcp`), che prima era un caso speciale gestito solo a mano nel README.

## Effetti sul README

L'output è quasi identico all'originale. Le uniche differenze:

- le tre statistiche errate sono corrette
- l'ordinamento è ora deterministico (featured → stelle decrescenti → nome), il che riordina cinque righe che erano fuori sequenza — per esempio CKAN MCP Server (57 ⭐) ora precede ISTAT MCP Server (23 ⭐)

## Verifica

- idempotente: esecuzioni ripetute non producono diff
- `--check` rileva il drift (testato alterando `stars` in un file)
- il generatore esce con errore su JSON non valido, categoria sconosciuta, URL mancante o marker assenti

## Follow-up possibili

Questa PR abilita la CI che esegue `--check` sulle PR, e in prospettiva un job schedulato che aggiorna `stars` via API GitHub — entrambi diventano banali ora che il README è derivato.