### PR TITLE
feat: aggiunge CI, link check e template per issue e PR

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentazione del Model Context Protocol
+    url: https://modelcontextprotocol.io/
+    about: Specifiche e guide ufficiali del protocollo MCP.
+  - name: Come contribuire
+    url: https://github.com/bsab/italia-mcp-servers/blob/main/CONTRIBUTING.md
+    about: Schema dei file in servers/ e procedura per aggiungere un server.

--- a/.github/ISSUE_TEMPLATE/nuovo-server.yml
+++ b/.github/ISSUE_TEMPLATE/nuovo-server.yml
@@ -1,0 +1,72 @@
+name: Proponi un server MCP
+description: Segnala un server MCP italiano da aggiungere al catalogo
+title: "[nuovo server] "
+labels: ["nuovo server"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Grazie per il contributo! Se preferisci, puoi aprire direttamente una PR
+        aggiungendo un file JSON in `servers/` — vedi
+        [CONTRIBUTING.md](https://github.com/bsab/italia-mcp-servers/blob/main/CONTRIBUTING.md).
+
+  - type: input
+    id: name
+    attributes:
+      label: Nome del server
+      placeholder: ISTAT MCP Server
+    validations:
+      required: true
+
+  - type: input
+    id: repository_url
+    attributes:
+      label: URL del repository
+      description: Per i server remoti senza repository pubblico, indica l'endpoint MCP.
+      placeholder: https://github.com/owner/repo
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Categoria
+      options:
+        - dati-statistiche
+        - legal-tech
+        - fatturazione
+        - pa-finanza-pubblica
+        - cybersecurity-compliance
+        - design-altro
+    validations:
+      required: true
+
+  - type: input
+    id: language
+    attributes:
+      label: Linguaggio principale
+      placeholder: Python
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Descrizione
+      description: Massimo 200 caratteri.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: criteria
+    attributes:
+      label: Criteri di inclusione
+      options:
+        - label: Implementa il Model Context Protocol
+          required: true
+        - label: È pertinente al contesto italiano (dati, normativa, servizi)
+          required: true
+        - label: Il repository è pubblico oppure l'endpoint MCP è accessibile
+          required: true
+        - label: Ha documentazione d'uso
+          required: true

--- a/.github/ISSUE_TEMPLATE/segnalazione.yml
+++ b/.github/ISSUE_TEMPLATE/segnalazione.yml
@@ -1,0 +1,33 @@
+name: Segnala un problema
+description: Link non funzionanti, informazioni errate o obsolete, server non più mantenuti
+title: "[problema] "
+labels: ["manutenzione"]
+body:
+  - type: input
+    id: server
+    attributes:
+      label: Server interessato
+      description: Nome del server o percorso del file in `servers/`.
+      placeholder: servers/ondata-istat-mcp-server.json
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Tipo di problema
+      options:
+        - Link non funzionante
+        - Informazione errata o obsoleta
+        - Server non più mantenuto o archiviato
+        - Altro
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Dettagli
+      description: Descrivi il problema e, se possibile, indica il valore corretto.
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Descrizione
+
+<!-- Cosa cambia questa PR e perché. -->
+
+## Checklist
+
+- [ ] Ho aggiunto o modificato un file JSON in `servers/` con nome in `kebab-case.json`
+- [ ] Ho eseguito `python3 scripts/build_readme.py` e incluso il README aggiornato
+- [ ] Non ho modificato a mano le tabelle del catalogo, i badge o le statistiche nel README
+- [ ] Il server implementa il Model Context Protocol ed è pertinente al contesto italiano
+
+<!--
+Se la PR non aggiunge un server (per esempio: correzioni alla documentazione o
+agli script), ignora le voci non pertinenti.
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  catalogo:
+    name: Valida catalogo e README
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verifica che i file in servers/ siano JSON validi
+        run: |
+          shopt -s nullglob
+          fail=0
+          for file in servers/*.json; do
+            if ! python3 -m json.tool --indent 2 "$file" > /dev/null; then
+              echo "::error file=$file::JSON non valido"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Verifica che i nomi dei file siano in kebab-case
+        run: |
+          shopt -s nullglob
+          fail=0
+          for file in servers/*.json; do
+            name=$(basename "$file" .json)
+            if [[ ! "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+              echo "::error file=$file::il nome del file deve essere in kebab-case"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Verifica che il README sia allineato a servers/
+        run: python3 scripts/build_readme.py --check

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,40 @@
+name: Link check
+
+# I link ai repository esterni si rompono nel tempo (repo archiviati, rinominati
+# o cancellati): questo controllo gira in modo schedulato invece che su ogni PR,
+# perche' un fallimento dipende da fattori esterni al contributo.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  lychee:
+    name: Verifica i link del catalogo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Controlla i link
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --max-retries 3
+            --accept 200,206,429
+            README.md 'servers/*.json'
+          fail: false
+
+      - name: Apri o aggiorna una issue in caso di link rotti
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Link non raggiungibili nel catalogo"
+          content-filepath: ./lychee/out.md
+          labels: manutenzione


### PR DESCRIPTION
## Problema

Il repository non aveva una directory `.github/`: nessun controllo automatico sui contributi e nessuna guida strutturata per chi apre issue o PR. In pratica, niente impediva di mergiare un JSON malformato, una categoria inesistente o un README non rigenerato — cioè esattamente il drift che ha reso necessaria la #4.

## Workflow CI

Gira su pull request e push su `main`:

1. i file in `servers/` sono JSON validi
2. i nomi dei file sono in `kebab-case`
3. il README è allineato a `servers/`, via `python3 scripts/build_readme.py --check`

Il terzo step copre più di quanto sembri: `build_readme.py` fallisce anche su categoria sconosciuta, URL mancante (`repository_url` / `site_url` / `mcp_endpoint`) o marker assenti nel README. Nessuna dipendenza esterna, solo Python della standard library.

## Link check separato

Il controllo dei link esterni sta in un workflow schedulato (lunedì mattina) invece che nella CI delle PR, deliberatamente: un repository di terze parti archiviato o rinominato non deve far fallire il contributo di qualcun altro. In caso di link rotti apre una issue con il report.

## Template

- **Proponi un server MCP** — form con categoria a tendina (allineata alle sei categorie ammesse) e checkbox sui criteri di inclusione
- **Segnala un problema** — link rotti, informazioni obsolete, server non più mantenuti
- **Template PR** — checklist che ricorda di rigenerare il README e di non toccare a mano le tabelle

## Verifica

- tutti i file YAML validati con `yaml.safe_load`
- gli step della CI eseguiti localmente sullo stato attuale del repo: passano

## Nota

Non ho aggiunto un `CODEOWNERS` per non fare assunzioni su chi debba fare la review. Se vuoi la review automatica sulle PR, è una riga in più.