### PR TITLE
feat: aggiunge JSON Schema e validatore per il catalogo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 ## Checklist
 
 - [ ] Ho aggiunto o modificato un file JSON in `servers/` con nome in `kebab-case.json`
+- [ ] Ho eseguito `python3 scripts/validate_servers.py` e passa
 - [ ] Ho eseguito `python3 scripts/build_readme.py` e incluso il README aggiornato
 - [ ] Non ho modificato a mano le tabelle del catalogo, i badge o le statistiche nel README
 - [ ] Il server implementa il Model Context Protocol ed è pertinente al contesto italiano

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,31 +22,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements.txt
 
-      - name: Verifica che i file in servers/ siano JSON validi
-        run: |
-          shopt -s nullglob
-          fail=0
-          for file in servers/*.json; do
-            if ! python3 -m json.tool --indent 2 "$file" > /dev/null; then
-              echo "::error file=$file::JSON non valido"
-              fail=1
-            fi
-          done
-          exit $fail
+      - name: Installa le dipendenze
+        run: python3 -m pip install -r scripts/requirements.txt
 
-      - name: Verifica che i nomi dei file siano in kebab-case
-        run: |
-          shopt -s nullglob
-          fail=0
-          for file in servers/*.json; do
-            name=$(basename "$file" .json)
-            if [[ ! "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
-              echo "::error file=$file::il nome del file deve essere in kebab-case"
-              fail=1
-            fi
-          done
-          exit $fail
+      - name: Valida i file in servers/ contro lo schema
+        run: python3 scripts/validate_servers.py
 
       - name: Verifica che il README sia allineato a servers/
         run: python3 scripts/build_readme.py --check

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "json.schemas": [
+    {
+      "fileMatch": ["/servers/*.json"],
+      "url": "./schema/server.schema.json"
+    }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,28 @@
 
 1. **Fai un fork** del repository
 2. Crea un file JSON in `servers/` con nome in `kebab-case.json`
-3. Compila tutti i campi richiesti (vedi schema nel README)
-4. Rigenera il README con `python3 scripts/build_readme.py` e includi il file aggiornato nel commit
+3. Compila i campi richiesti da [`schema/server.schema.json`](schema/server.schema.json)
+4. Valida e rigenera il README, includendo il file aggiornato nel commit:
+
+```bash
+python3 -m pip install -r scripts/requirements.txt
+python3 scripts/validate_servers.py
+python3 scripts/build_readme.py
+```
+
 5. Apri una Pull Request con titolo: `feat: added Nome Server`
 
 > Le tabelle del catalogo, i badge e le statistiche nel README sono generati
 > automaticamente dai file in `servers/`: non modificarli a mano, altrimenti le
 > modifiche vengono sovrascritte alla rigenerazione successiva.
+
+## Script di manutenzione
+
+| Comando | Cosa fa |
+|---------|---------|
+| `python3 scripts/validate_servers.py` | Valida `servers/` contro lo schema e controlla nomi di file, duplicati e URL |
+| `python3 scripts/build_readme.py` | Rigenera badge, tabelle e statistiche del README |
+| `python3 scripts/build_readme.py --check` | Verifica l'allineamento senza riscrivere nulla (usato dalla CI) |
 
 ## Criteri
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 Conosci un server MCP italiano non presente in questo catalogo? Apri una PR!
 
 1. Crea un file JSON in `servers/` con il nome in `kebab-case.json`
-2. Segui lo schema:
+2. Segui lo schema — la definizione formale è in
+   [`schema/server.schema.json`](schema/server.schema.json):
 
 ```json
 {
@@ -107,6 +108,7 @@ Conosci un server MCP italiano non presente in questo catalogo? Apri una PR!
   "repository_url": "https://github.com/owner/repo",
   "site_url": "https://...",
   "mcp_endpoint": "https://.../mcp",
+  "transport": "streamable-http",
   "author": "owner",
   "language": "Python",
   "license": "MIT",
@@ -118,19 +120,23 @@ Conosci un server MCP italiano non presente in questo catalogo? Apri una PR!
 }
 ```
 
-I campi `site_url`, `mcp_endpoint`, `short_description` e `featured` sono opzionali:
-`short_description` sostituisce `description` nelle tabelle del catalogo,
-`mcp_endpoint` aggiunge il link all'endpoint remoto e `featured: true` mette il
-progetto in evidenza in cima alla sua categoria.
+I campi `site_url`, `mcp_endpoint`, `transport`, `short_description`, `featured` e
+`tools` sono opzionali: `short_description` sostituisce `description` nelle tabelle
+del catalogo, `mcp_endpoint` aggiunge il link all'endpoint remoto e `featured: true`
+mette il progetto in evidenza in cima alla sua categoria. Almeno uno tra
+`repository_url`, `site_url` e `mcp_endpoint` è obbligatorio.
 
-3. **Rigenera il README** — le tabelle, i badge e le statistiche sono generati dai
-   file in `servers/` e non vanno modificati a mano:
+3. **Valida e rigenera il README** — le tabelle, i badge e le statistiche sono
+   generati dai file in `servers/` e non vanno modificati a mano:
 
 ```bash
+python3 -m pip install -r scripts/requirements.txt
+python3 scripts/validate_servers.py
 python3 scripts/build_readme.py
 ```
 
-La CI verifica l'allineamento con `python3 scripts/build_readme.py --check`.
+La CI esegue gli stessi controlli su ogni pull request, con
+`python3 scripts/build_readme.py --check` per verificare l'allineamento del README.
 
 ### Categorie ammesse
 

--- a/schema/server.schema.json
+++ b/schema/server.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/bsab/italia-mcp-servers/blob/main/schema/server.schema.json",
+  "title": "Server MCP italiano",
+  "description": "Schema di una voce del catalogo, corrispondente a un file in servers/.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "author",
+    "language",
+    "license",
+    "stars",
+    "category",
+    "description",
+    "tags"
+  ],
+  "anyOf": [
+    { "required": ["repository_url"] },
+    { "required": ["site_url"] },
+    { "required": ["mcp_endpoint"] }
+  ],
+  "properties": {
+    "name": {
+      "description": "Nome del server come mostrato nel catalogo.",
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 80
+    },
+    "repository_url": {
+      "description": "URL del repository pubblico. Assente solo per i server remoti senza codice pubblicato.",
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://"
+    },
+    "site_url": {
+      "description": "Sito o documentazione del progetto.",
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://"
+    },
+    "mcp_endpoint": {
+      "description": "Endpoint MCP remoto, per i server utilizzabili senza installazione locale.",
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://"
+    },
+    "transport": {
+      "description": "Trasporto MCP esposto dal server.",
+      "type": "string",
+      "enum": ["stdio", "sse", "streamable-http"]
+    },
+    "author": {
+      "description": "Utente o organizzazione che pubblica il server.",
+      "type": "string",
+      "minLength": 1
+    },
+    "language": {
+      "description": "Linguaggio di implementazione principale.",
+      "type": "string",
+      "enum": ["Python", "TypeScript", "JavaScript", "Go", "Rust", "Java", "C#", "Ruby", "PHP"]
+    },
+    "license": {
+      "description": "Identificativo SPDX della licenza, oppure un valore che indica una licenza non dichiarata.",
+      "type": "string",
+      "minLength": 1
+    },
+    "stars": {
+      "description": "Stelle su GitHub al momento dell'ultimo aggiornamento.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "category": {
+      "description": "Categoria del catalogo. Deve corrispondere alle sezioni definite in scripts/build_readme.py.",
+      "type": "string",
+      "enum": [
+        "dati-statistiche",
+        "legal-tech",
+        "fatturazione",
+        "pa-finanza-pubblica",
+        "cybersecurity-compliance",
+        "design-altro"
+      ]
+    },
+    "featured": {
+      "description": "Se true, il server compare in evidenza in cima alla sua categoria.",
+      "type": "boolean"
+    },
+    "short_description": {
+      "description": "Descrizione compatta usata nelle tabelle del README. In assenza viene usata description.",
+      "type": "string",
+      "minLength": 10,
+      "maxLength": 120
+    },
+    "description": {
+      "description": "Descrizione del server, massimo 200 caratteri.",
+      "type": "string",
+      "minLength": 20,
+      "maxLength": 200
+    },
+    "tags": {
+      "description": "Parole chiave in kebab-case minuscolo.",
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 8,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+      }
+    },
+    "tools": {
+      "description": "Nomi dei tool MCP esposti, quando documentati.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9_.-]+$"
+      }
+    }
+  }
+}

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+# Dipendenze degli script di manutenzione del catalogo.
+# scripts/build_readme.py non richiede nulla: usa solo la standard library.
+jsonschema>=4.0

--- a/scripts/validate_servers.py
+++ b/scripts/validate_servers.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Valida i file in servers/ contro schema/server.schema.json.
+
+Oltre allo schema verifica i vincoli che riguardano il catalogo nel suo insieme
+(nomi di file, unicita' di nomi e URL) e che non sono esprimibili sul singolo file.
+
+Uso:
+    python3 scripts/validate_servers.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+try:
+    from jsonschema import Draft202012Validator
+except ImportError:
+    sys.exit(
+        "Manca la dipendenza jsonschema. Installala con:\n"
+        "    python3 -m pip install -r scripts/requirements.txt"
+    )
+
+ROOT = Path(__file__).resolve().parent.parent
+SERVERS_DIR = ROOT / "servers"
+SCHEMA_PATH = ROOT / "schema" / "server.schema.json"
+
+FILENAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+URL_FIELDS = ("repository_url", "site_url", "mcp_endpoint")
+
+
+def relative(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def describe(error) -> str:
+    location = "".join(f"[{part!r}]" for part in error.absolute_path)
+    # L'anyOf di primo livello serve solo a richiedere almeno un URL: il messaggio
+    # predefinito di jsonschema riporterebbe l'intero oggetto, rendendolo illeggibile.
+    if error.validator == "anyOf" and not error.absolute_path:
+        return "manca almeno uno tra repository_url, site_url e mcp_endpoint"
+    return f"{location or '<root>'}: {error.message}"
+
+
+def main() -> int:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    paths = sorted(SERVERS_DIR.glob("*.json"))
+    if not paths:
+        print(f"{relative(SERVERS_DIR)}: nessun server trovato", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    names: defaultdict[str, list[Path]] = defaultdict(list)
+    urls: defaultdict[str, list[Path]] = defaultdict(list)
+
+    for path in paths:
+        if not FILENAME_RE.match(path.stem):
+            errors.append(f"{relative(path)}: il nome del file deve essere in kebab-case")
+
+        try:
+            server = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"{relative(path)}: JSON non valido: {exc}")
+            continue
+
+        if not isinstance(server, dict):
+            errors.append(f"{relative(path)}: il file deve contenere un oggetto JSON")
+            continue
+
+        for error in sorted(validator.iter_errors(server), key=lambda e: list(e.absolute_path)):
+            errors.append(f"{relative(path)}: {describe(error)}")
+
+        if isinstance(server.get("name"), str):
+            names[server["name"].casefold()].append(path)
+        for field in URL_FIELDS:
+            url = server.get(field)
+            if isinstance(url, str):
+                urls[url.rstrip("/")].append(path)
+
+    for name, duplicates in sorted(names.items()):
+        if len(duplicates) > 1:
+            files = ", ".join(relative(p) for p in duplicates)
+            errors.append(f"nome duplicato {name!r}: {files}")
+
+    for url, duplicates in sorted(urls.items()):
+        # Lo stesso file puo' ripetere un URL in piu' campi (es. site_url == mcp_endpoint).
+        distinct = sorted({p for p in duplicates})
+        if len(distinct) > 1:
+            files = ", ".join(relative(p) for p in distinct)
+            errors.append(f"URL duplicato {url}: {files}")
+
+    if errors:
+        prefix = "::error::" if os.environ.get("GITHUB_ACTIONS") else ""
+        for error in errors:
+            print(f"{prefix}{error}")
+        print(f"\n{len(errors)} errori in {len(paths)} file.", file=sys.stderr)
+        return 1
+
+    print(f"{len(paths)} server validi.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problema

I file in `servers/` non avevano una definizione formale. La CI introdotta nella #5 verificava solo che fossero JSON sintatticamente validi, quindi sarebbero passati inosservati: una categoria inesistente, un campo scritto male, `stars` negativo, una voce senza alcun URL, tag con spazi e maiuscole, un server duplicato.

Non è teorico: prima della #4 il repo aveva già due file con campi extra non documentati (`transport`, `tools`, `mcp_endpoint`) e uno senza `repository_url`, tutti scoperti solo leggendo i file uno per uno.

## Soluzione

**`schema/server.schema.json`** — JSON Schema draft 2020-12, con `additionalProperties: false` per intercettare i refusi nei nomi dei campi. I vincoli riflettono i dati reali: `description` max 200 caratteri, `category` e `language` come enum, tag in kebab-case, `transport` limitato ai trasporti MCP effettivi.

Il vincolo più utile è l'`anyOf` di primo livello: serve almeno uno tra `repository_url`, `site_url` e `mcp_endpoint`. Così `cruscotto-italia-mcp` — server remoto senza repository pubblico — resta valido senza eccezioni scritte a mano.

**`scripts/validate_servers.py`** — applica lo schema e aggiunge i controlli sull'insieme del catalogo, che sul singolo file non sono esprimibili: nomi dei file in kebab-case, nomi dei server e URL non duplicati.

## CI

Il validatore sostituisce i due step inline su JSON e nomi dei file: erano un sottoinsieme di quello che verifica ora. Aggiunta la cache pip.

## Verifica

**Tutti e 30 i server esistenti passano senza modifiche** — lo schema descrive i dati attuali, non impone una migrazione.

Ho poi iniettato errori uno alla volta per confermare che vengano intercettati:

| Errore iniettato | Esito |
|---|---|
| categoria inesistente | ✅ |
| campo sconosciuto (`colore`) | ✅ |
| `stars` negativo | ✅ |
| descrizione oltre 200 caratteri | ✅ |
| tag non kebab-case | ✅ |
| nessun URL | ✅ |
| linguaggio non in enum | ✅ |
| nome file non kebab-case | ✅ |
| nome server duplicato | ✅ |
| URL duplicato tra due file | ✅ |

Il messaggio per "nessun URL" ha una gestione dedicata: quello predefinito di `jsonschema` per l'`anyOf` avrebbe stampato l'intero oggetto.

## Extra

`.vscode/settings.json` associa lo schema ai file in `servers/`, così chi contribuisce ha autocompletamento e validazione live nell'editor, prima ancora di eseguire lo script.

## Nota sulle dipendenze

Prima dipendenza esterna del repo (`jsonschema`, in `scripts/requirements.txt`). `build_readme.py` resta stdlib-only.