### PR TITLE
feat: normalizza le licenze su identificatori SPDX

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 | Python | 16 |
 | TypeScript | 13 |
 | JavaScript | 1 |
-| Licenze open source | 22 |
+| Licenze open source | 27 |
+| Senza licenza dichiarata | 3 |
 | Categorie | 6 |
 <!-- END:stats -->
 
@@ -112,8 +113,7 @@ Conosci un server MCP italiano non presente in questo catalogo? Apri una PR!
   "author": "owner",
   "language": "Python",
   "license": "MIT",
-  "stars": 0,
-  "category": "dati-statistiche",
+  "stars": 0,  "category": "dati-statistiche",
   "short_description": "Descrizione compatta per la tabella del catalogo.",
   "description": "Breve descrizione del server (max 200 caratteri).",
   "tags": ["tag1", "tag2", "tag3"]
@@ -125,6 +125,11 @@ I campi `site_url`, `mcp_endpoint`, `transport`, `short_description`, `featured`
 del catalogo, `mcp_endpoint` aggiunge il link all'endpoint remoto e `featured: true`
 mette il progetto in evidenza in cima alla sua categoria. Almeno uno tra
 `repository_url`, `site_url` e `mcp_endpoint` è obbligatorio.
+
+Il campo `license` accetta un identificativo [SPDX](https://spdx.org/licenses/) —
+`"MIT"`, `"Apache-2.0"`, `"AGPL-3.0"`… — oppure `null` se il progetto non dichiara
+alcuna licenza. Valori come `"n/a"` o `"unknown"` vengono rifiutati dalla
+validazione: usa `null`.
 
 3. **Valida e rigenera il README** — le tabelle, i badge e le statistiche sono
    generati dai file in `servers/` e non vanno modificati a mano:

--- a/schema/server.schema.json
+++ b/schema/server.schema.json
@@ -61,9 +61,24 @@
       "enum": ["Python", "TypeScript", "JavaScript", "Go", "Rust", "Java", "C#", "Ruby", "PHP"]
     },
     "license": {
-      "description": "Identificativo SPDX della licenza, oppure un valore che indica una licenza non dichiarata.",
-      "type": "string",
-      "minLength": 1
+      "description": "Identificativo SPDX della licenza del codice, oppure null se non e' dichiarata. Per aggiungere una licenza non presente, estendi questo elenco.",
+      "type": ["string", "null"],
+      "enum": [
+        null,
+        "MIT",
+        "Apache-2.0",
+        "AGPL-3.0",
+        "GPL-3.0",
+        "GPL-2.0",
+        "LGPL-3.0",
+        "BSD-2-Clause",
+        "BSD-3-Clause",
+        "MPL-2.0",
+        "EUPL-1.2",
+        "ISC",
+        "Unlicense",
+        "CC0-1.0"
+      ]
     },
     "stars": {
       "description": "Stelle su GitHub al momento dell'ultimo aggiornamento.",

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -31,9 +31,6 @@ CATEGORIES = [
 # Abbreviazioni usate nella colonna "Lang" del catalogo.
 LANGUAGE_ABBR = {"TypeScript": "TS", "JavaScript": "JS"}
 
-# Valori di `license` che non identificano una licenza open source riconosciuta.
-NON_OSS_LICENSES = {"n/a", "unknown", "noassertion", ""}
-
 BLOCK_RE_TEMPLATE = r"(<!-- BEGIN:{name} -->\n)(?:.*?)(\n<!-- END:{name} -->)"
 
 
@@ -112,11 +109,8 @@ def render_stats(servers: list[dict]) -> str:
         language = server.get("language", "—")
         languages[language] = languages.get(language, 0) + 1
 
-    oss = sum(
-        1
-        for server in servers
-        if str(server.get("license") or "").strip().lower() not in NON_OSS_LICENSES
-    )
+    # `license` e' null quando il progetto non dichiara una licenza.
+    oss = sum(1 for server in servers if server.get("license"))
 
     lines = [
         "| Metrica | Valore |",
@@ -126,6 +120,8 @@ def render_stats(servers: list[dict]) -> str:
     for language, count in sorted(languages.items(), key=lambda kv: (-kv[1], kv[0])):
         lines.append(f"| {language} | {count} |")
     lines.append(f"| Licenze open source | {oss} |")
+    if len(servers) - oss:
+        lines.append(f"| Senza licenza dichiarata | {len(servers) - oss} |")
     lines.append(f"| Categorie | {len({s['category'] for s in servers})} |")
     return "\n".join(lines)
 

--- a/servers/avvocati-e-mac-normattiva-mcp.json
+++ b/servers/avvocati-e-mac-normattiva-mcp.json
@@ -3,7 +3,7 @@
   "repository_url": "https://github.com/avvocati-e-mac/normattiva-mcp",
   "author": "avvocati-e-mac",
   "language": "Python",
-  "license": "NOASSERTION",
+  "license": "MIT",
   "stars": 0,
   "category": "legal-tech",
   "short_description": "CLI + MCP per citare norme da Normattiva.it",

--- a/servers/badbat75-fattureincloudmcp.json
+++ b/servers/badbat75-fattureincloudmcp.json
@@ -3,7 +3,7 @@
   "repository_url": "https://github.com/badbat75/FattureInCloudMCP",
   "author": "badbat75",
   "language": "TypeScript",
-  "license": "n/a",
+  "license": "MIT",
   "stars": 0,
   "category": "fatturazione",
   "short_description": "Fatture in Cloud API v2, CRUD completo",

--- a/servers/cruscotto-italia-mcp.json
+++ b/servers/cruscotto-italia-mcp.json
@@ -5,7 +5,7 @@
   "transport": "streamable-http",
   "author": "agid",
   "language": "TypeScript",
-  "license": "unknown",
+  "license": null,
   "stars": 0,
   "category": "pa-finanza-pubblica",
   "short_description": "Dati comunali per codice ISTAT: demografia, SIOPE, PNRR, sanità",

--- a/servers/gsaccardi-dichiarino-mcp.json
+++ b/servers/gsaccardi-dichiarino-mcp.json
@@ -3,7 +3,7 @@
   "repository_url": "https://github.com/gsaccardi/dichiarino-mcp",
   "author": "gsaccardi",
   "language": "Python",
-  "license": "NOASSERTION",
+  "license": "Apache-2.0",
   "stars": 23,
   "category": "pa-finanza-pubblica",
   "featured": true,

--- a/servers/makremriahi99-mcp-meteo-italia.json
+++ b/servers/makremriahi99-mcp-meteo-italia.json
@@ -3,7 +3,7 @@
   "repository_url": "https://github.com/makremriahi99/MCP-Meteo-Italia",
   "author": "makremriahi99",
   "language": "Python",
-  "license": "n/a",
+  "license": null,
   "stars": 0,
   "category": "design-altro",
   "short_description": "Meteo in tempo reale con FastMCP + Gradio",

--- a/servers/manolozocco-istat-mcp-suite.json
+++ b/servers/manolozocco-istat-mcp-suite.json
@@ -3,7 +3,7 @@
   "repository_url": "https://github.com/ManoloZocco/istat-mcp-suite",
   "author": "ManoloZocco",
   "language": "Python",
-  "license": "n/a",
+  "license": "MIT",
   "stars": 0,
   "category": "dati-statistiche",
   "short_description": "Server unificato per dataset ISTAT",

--- a/servers/marckdev-aruba-fatture-mcp.json
+++ b/servers/marckdev-aruba-fatture-mcp.json
@@ -3,7 +3,7 @@
   "repository_url": "https://github.com/MarckDev/aruba-fatture-mcp",
   "author": "MarckDev",
   "language": "TypeScript",
-  "license": "n/a",
+  "license": "MIT",
   "stars": 3,
   "category": "fatturazione",
   "short_description": "Aruba Fatturazione Elettronica + SDI",

--- a/servers/simonberg255-anac-mcp.json
+++ b/servers/simonberg255-anac-mcp.json
@@ -3,7 +3,7 @@
   "repository_url": "https://github.com/SimonBerg255/anac-mcp",
   "author": "SimonBerg255",
   "language": "Python",
-  "license": "n/a",
+  "license": null,
   "stars": 4,
   "category": "pa-finanza-pubblica",
   "short_description": "Appalti pubblici ANAC (BDNCP)",


### PR DESCRIPTION
> Impilata su #6 (base: `bsab-add-json-schema`). Da mergiare dopo.

## Problema

Il campo `license` usava tre valori diversi per dire la stessa cosa — `n/a` (5), `NOASSERTION` (2), `unknown` (1) — rendendo impossibile contare le licenze in modo affidabile e costringendo `build_readme.py` a mantenere una lista di valori speciali da escludere.

## Le licenze erano anche sbagliate

Invece di rimappare i valori alla cieca, ho verificato ogni voce contro la fonte reale: API GitHub, testo del file `LICENSE`, `package.json`, `pyproject.toml`. Cinque erano semplicemente errate:

| Server | Prima | Dopo | Fonte |
|---|---|---|---|
| `badbat75-fattureincloudmcp` | `n/a` | `MIT` | `package.json` |
| `manolozocco-istat-mcp-suite` | `n/a` | `MIT` | rilevata da GitHub |
| `marckdev-aruba-fatture-mcp` | `n/a` | `MIT` | `package.json` |
| `avvocati-e-mac-normattiva-mcp` | `NOASSERTION` | `MIT` | testo del `LICENSE` |
| `gsaccardi-dichiarino-mcp` | `NOASSERTION` | `Apache-2.0` | testo del `LICENSE` |

I `NOASSERTION` erano falsi negativi: i repository *hanno* un `LICENSE`, ma con l'intestazione modificata, quindi il classificatore di GitHub non lo riconosce.

Ho anche riverificato i casi che sembravano già a posto: `stucchi-italy-opendata-mcp` risultava senza licenza per l'API GitHub ma la dichiara in `pyproject.toml` (MIT confermato), e `DoveVannoINostriSoldi` è AGPL-3.0 confermato leggendo il testo.

## I tre null residui

| Server | Perché |
|---|---|
| `makremriahi99-mcp-meteo-italia` | nessuna licenza dichiarata da nessuna parte |
| `simonberg255-anac-mcp` | il CC-BY 4.0 citato nel README riguarda **i dati ANAC**, non il codice |
| `cruscotto-italia-mcp` | server remoto, nessun repository pubblico |

## Schema

`license` accetta ora un enum di identificatori SPDX oppure `null`. Verificato che `"n/a"`, `"unknown"`, `"NOASSERTION"` e `""` vengono tutti rifiutati dalla validazione, quindi i segnaposto non possono rientrare.

L'enum è volutamente chiuso: aggiungere una licenza richiede una riga nello schema, ma in cambio nessuno può inventare un formato nuovo.

## Effetto sul README

`Licenze open source` passa da 22 a **27**, e ho aggiunto una riga `Senza licenza dichiarata` per rendere esplicito il residuo invece di lasciarlo implicito nella differenza.

## Semplificazione

Sparisce la costante `NON_OSS_LICENSES` da `build_readme.py`: ora il conteggio è `if server.get("license")`.
