### PR TITLE
feat: pubblica catalog.json e una pagina di consultazione su Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Verifica che il README sia allineato a servers/
         run: python3 scripts/build_readme.py --check
+
+      - name: Genera e valida il catalogo pubblicato
+        run: python3 scripts/build_catalog.py --output "$RUNNER_TEMP/site"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Pages
+
+# Pubblica il catalogo aggregato e la pagina di consultazione su GitHub Pages.
+# Il contenuto e' generato da servers/: non esiste nulla di scritto a mano.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Un solo deploy alla volta, senza annullare quello in corso.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Genera il sito
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Genera site/
+        run: python3 scripts/build_catalog.py
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Pubblica su Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Sito generato da scripts/build_catalog.py, pubblicato su GitHub Pages.
+site/
+
+__pycache__/
+*.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,24 @@ python3 scripts/build_readme.py
 | `python3 scripts/validate_servers.py` | Valida `servers/` contro lo schema e controlla nomi di file, duplicati e URL |
 | `python3 scripts/build_readme.py` | Rigenera badge, tabelle e statistiche del README |
 | `python3 scripts/build_readme.py --check` | Verifica l'allineamento senza riscrivere nulla (usato dalla CI) |
+| `python3 scripts/build_catalog.py` | Genera `site/` con `catalog.json` e la pagina di consultazione |
+
+## Catalogo in formato JSON
+
+Il catalogo è pubblicato anche in forma leggibile dalle macchine, rigenerato a ogni
+push su `main`:
+
+| Risorsa | URL |
+|---------|-----|
+| Catalogo | <https://bsab.github.io/italia-mcp-servers/catalog.json> |
+| Schema del catalogo | <https://bsab.github.io/italia-mcp-servers/schema/catalog.schema.json> |
+| Schema di un server | <https://bsab.github.io/italia-mcp-servers/schema/server.schema.json> |
+| Pagina di consultazione | <https://bsab.github.io/italia-mcp-servers/> |
+
+Il campo `version` indica la versione della struttura del documento e cambia solo
+per modifiche incompatibili. Ogni voce di `servers` contiene i campi del file
+corrispondente più `url`, il link canonico (`repository_url`, altrimenti
+`site_url`, altrimenti `mcp_endpoint`).
 
 ## Criteri
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ Il Model Context Protocol permette agli assistenti AI (Claude, Cursor, VS Code C
 | Categorie | 6 |
 <!-- END:stats -->
 
+## 🔌 Catalogo in formato JSON
+
+Il catalogo è pubblicato anche in forma leggibile dalle macchine, rigenerato
+automaticamente a ogni aggiornamento:
+
+```bash
+curl -s https://bsab.github.io/italia-mcp-servers/catalog.json | jq '.servers[] | .name'
+```
+
+| Risorsa | URL |
+|---------|-----|
+| Catalogo | <https://bsab.github.io/italia-mcp-servers/catalog.json> |
+| Schema del catalogo | <https://bsab.github.io/italia-mcp-servers/schema/catalog.schema.json> |
+| Schema di un server | <https://bsab.github.io/italia-mcp-servers/schema/server.schema.json> |
+| Ricerca e filtri | <https://bsab.github.io/italia-mcp-servers/> |
+
+Il campo `version` indica la versione della struttura del documento e cambia solo
+per modifiche incompatibili. Ogni voce di `servers` contiene i campi del file in
+`servers/` più `url`, il link canonico del progetto.
+
 ## 🤝 Come contribuire
 
 Conosci un server MCP italiano non presente in questo catalogo? Apri una PR!

--- a/schema/catalog.schema.json
+++ b/schema/catalog.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bsab.github.io/italia-mcp-servers/schema/catalog.schema.json",
+  "title": "Catalogo dei server MCP italiani",
+  "description": "Struttura di catalog.json, il catalogo aggregato pubblicato su GitHub Pages.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "generated_at", "source", "count", "categories", "servers"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "version": {
+      "description": "Versione della struttura del documento. Cambia solo per modifiche incompatibili.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "generated_at": {
+      "description": "Istante di generazione, in UTC.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "description": "Repository da cui il catalogo e' generato.",
+      "type": "string",
+      "format": "uri"
+    },
+    "license": {
+      "description": "Licenza del catalogo, distinta da quelle dei singoli server.",
+      "type": "string"
+    },
+    "count": {
+      "description": "Numero di voci in servers.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "categories": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "label", "emoji", "description", "count"],
+        "properties": {
+          "id": { "type": "string" },
+          "label": { "type": "string" },
+          "emoji": { "type": "string" },
+          "description": { "type": "string" },
+          "count": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "server.schema.json#/$defs/server",
+        "required": ["url"],
+        "properties": {
+          "url": {
+            "description": "Link canonico del server: repository_url, altrimenti site_url, altrimenti mcp_endpoint. Presente solo nel catalogo aggregato, non nei file in servers/.",
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "unevaluatedProperties": false
+      }
+    }
+  }
+}

--- a/schema/server.schema.json
+++ b/schema/server.schema.json
@@ -1,137 +1,173 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/bsab/italia-mcp-servers/blob/main/schema/server.schema.json",
+  "$id": "https://bsab.github.io/italia-mcp-servers/schema/server.schema.json",
   "title": "Server MCP italiano",
   "description": "Schema di una voce del catalogo, corrispondente a un file in servers/.",
-  "type": "object",
-  "additionalProperties": false,
-  "required": [
-    "name",
-    "author",
-    "language",
-    "license",
-    "stars",
-    "category",
-    "description",
-    "tags"
-  ],
-  "anyOf": [
-    { "required": ["repository_url"] },
-    { "required": ["site_url"] },
-    { "required": ["mcp_endpoint"] }
-  ],
-  "properties": {
-    "name": {
-      "description": "Nome del server come mostrato nel catalogo.",
-      "type": "string",
-      "minLength": 2,
-      "maxLength": 80
-    },
-    "repository_url": {
-      "description": "URL del repository pubblico. Assente solo per i server remoti senza codice pubblicato.",
-      "type": "string",
-      "format": "uri",
-      "pattern": "^https://"
-    },
-    "site_url": {
-      "description": "Sito o documentazione del progetto.",
-      "type": "string",
-      "format": "uri",
-      "pattern": "^https://"
-    },
-    "mcp_endpoint": {
-      "description": "Endpoint MCP remoto, per i server utilizzabili senza installazione locale.",
-      "type": "string",
-      "format": "uri",
-      "pattern": "^https://"
-    },
-    "transport": {
-      "description": "Trasporto MCP esposto dal server.",
-      "type": "string",
-      "enum": ["stdio", "sse", "streamable-http"]
-    },
-    "author": {
-      "description": "Utente o organizzazione che pubblica il server.",
-      "type": "string",
-      "minLength": 1
-    },
-    "language": {
-      "description": "Linguaggio di implementazione principale.",
-      "type": "string",
-      "enum": ["Python", "TypeScript", "JavaScript", "Go", "Rust", "Java", "C#", "Ruby", "PHP"]
-    },
-    "license": {
-      "description": "Identificativo SPDX della licenza del codice, oppure null se non e' dichiarata. Per aggiungere una licenza non presente, estendi questo elenco.",
-      "type": ["string", "null"],
-      "enum": [
-        null,
-        "MIT",
-        "Apache-2.0",
-        "AGPL-3.0",
-        "GPL-3.0",
-        "GPL-2.0",
-        "LGPL-3.0",
-        "BSD-2-Clause",
-        "BSD-3-Clause",
-        "MPL-2.0",
-        "EUPL-1.2",
-        "ISC",
-        "Unlicense",
-        "CC0-1.0"
-      ]
-    },
-    "stars": {
-      "description": "Stelle su GitHub al momento dell'ultimo aggiornamento.",
-      "type": "integer",
-      "minimum": 0
-    },
-    "category": {
-      "description": "Categoria del catalogo. Deve corrispondere alle sezioni definite in scripts/build_readme.py.",
-      "type": "string",
-      "enum": [
-        "dati-statistiche",
-        "legal-tech",
-        "fatturazione",
-        "pa-finanza-pubblica",
-        "cybersecurity-compliance",
-        "design-altro"
-      ]
-    },
-    "featured": {
-      "description": "Se true, il server compare in evidenza in cima alla sua categoria.",
-      "type": "boolean"
-    },
-    "short_description": {
-      "description": "Descrizione compatta usata nelle tabelle del README. In assenza viene usata description.",
-      "type": "string",
-      "minLength": 10,
-      "maxLength": 120
-    },
-    "description": {
-      "description": "Descrizione del server, massimo 200 caratteri.",
-      "type": "string",
-      "minLength": 20,
-      "maxLength": 200
-    },
-    "tags": {
-      "description": "Parole chiave in kebab-case minuscolo.",
-      "type": "array",
-      "minItems": 2,
-      "maxItems": 8,
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
-      }
-    },
-    "tools": {
-      "description": "Nomi dei tool MCP esposti, quando documentati.",
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "pattern": "^[A-Za-z0-9_.-]+$"
+  "$ref": "#/$defs/server",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "server": {
+      "title": "Voce del catalogo",
+      "description": "Campi comuni a un file in servers/ e a una voce di catalog.json.",
+      "type": "object",
+      "required": [
+        "name",
+        "author",
+        "language",
+        "license",
+        "stars",
+        "category",
+        "description",
+        "tags"
+      ],
+      "anyOf": [
+        {
+          "required": [
+            "repository_url"
+          ]
+        },
+        {
+          "required": [
+            "site_url"
+          ]
+        },
+        {
+          "required": [
+            "mcp_endpoint"
+          ]
+        }
+      ],
+      "properties": {
+        "name": {
+          "description": "Nome del server come mostrato nel catalogo.",
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 80
+        },
+        "repository_url": {
+          "description": "URL del repository pubblico. Assente solo per i server remoti senza codice pubblicato.",
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://"
+        },
+        "site_url": {
+          "description": "Sito o documentazione del progetto.",
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://"
+        },
+        "mcp_endpoint": {
+          "description": "Endpoint MCP remoto, per i server utilizzabili senza installazione locale.",
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://"
+        },
+        "transport": {
+          "description": "Trasporto MCP esposto dal server.",
+          "type": "string",
+          "enum": [
+            "stdio",
+            "sse",
+            "streamable-http"
+          ]
+        },
+        "author": {
+          "description": "Utente o organizzazione che pubblica il server.",
+          "type": "string",
+          "minLength": 1
+        },
+        "language": {
+          "description": "Linguaggio di implementazione principale.",
+          "type": "string",
+          "enum": [
+            "Python",
+            "TypeScript",
+            "JavaScript",
+            "Go",
+            "Rust",
+            "Java",
+            "C#",
+            "Ruby",
+            "PHP"
+          ]
+        },
+        "license": {
+          "description": "Identificativo SPDX della licenza del codice, oppure null se non e' dichiarata. Per aggiungere una licenza non presente, estendi questo elenco.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            null,
+            "MIT",
+            "Apache-2.0",
+            "AGPL-3.0",
+            "GPL-3.0",
+            "GPL-2.0",
+            "LGPL-3.0",
+            "BSD-2-Clause",
+            "BSD-3-Clause",
+            "MPL-2.0",
+            "EUPL-1.2",
+            "ISC",
+            "Unlicense",
+            "CC0-1.0"
+          ]
+        },
+        "stars": {
+          "description": "Stelle su GitHub al momento dell'ultimo aggiornamento.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "category": {
+          "description": "Categoria del catalogo. Deve corrispondere alle sezioni definite in scripts/build_readme.py.",
+          "type": "string",
+          "enum": [
+            "dati-statistiche",
+            "legal-tech",
+            "fatturazione",
+            "pa-finanza-pubblica",
+            "cybersecurity-compliance",
+            "design-altro"
+          ]
+        },
+        "featured": {
+          "description": "Se true, il server compare in evidenza in cima alla sua categoria.",
+          "type": "boolean"
+        },
+        "short_description": {
+          "description": "Descrizione compatta usata nelle tabelle del README. In assenza viene usata description.",
+          "type": "string",
+          "minLength": 10,
+          "maxLength": 120
+        },
+        "description": {
+          "description": "Descrizione del server, massimo 200 caratteri.",
+          "type": "string",
+          "minLength": 20,
+          "maxLength": 200
+        },
+        "tags": {
+          "description": "Parole chiave in kebab-case minuscolo.",
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 8,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+          }
+        },
+        "tools": {
+          "description": "Nomi dei tool MCP esposti, quando documentati.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_.-]+$"
+          }
+        }
       }
     }
   }

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Costruisce il sito statico pubblicato su GitHub Pages.
+
+Genera in site/:
+  - catalog.json                 catalogo aggregato, leggibile dalle macchine
+  - schema/server.schema.json    copia dello schema, referenziata da catalog.json
+  - index.html                   pagina di consultazione con ricerca e filtri
+
+Uso:
+    python3 scripts/build_catalog.py [--output site]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from build_readme import CATEGORIES, load_servers, primary_url, sort_key  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_DIR = ROOT / "schema"
+SERVER_SCHEMA = SCHEMA_DIR / "server.schema.json"
+CATALOG_SCHEMA = SCHEMA_DIR / "catalog.schema.json"
+TEMPLATE_PATH = Path(__file__).resolve().parent / "templates" / "index.html"
+
+BASE_URL = "https://bsab.github.io/italia-mcp-servers"
+
+# Versione della struttura di catalog.json. Va incrementata a ogni modifica
+# incompatibile, perche' l'URL pubblico e' a tutti gli effetti un'API.
+CATALOG_VERSION = 1
+
+
+def build_catalog(servers: list[dict]) -> dict:
+    by_category = {category.slug: 0 for category in CATEGORIES}
+    for server in servers:
+        by_category[server["category"]] += 1
+
+    entries = []
+    for server in sorted(servers, key=sort_key):
+        entry = {key: value for key, value in server.items() if not key.startswith("_")}
+        entry["url"] = primary_url(server)
+        entries.append(entry)
+
+    return {
+        "$schema": f"{BASE_URL}/schema/catalog.schema.json",
+        "version": CATALOG_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "source": "https://github.com/bsab/italia-mcp-servers",
+        "license": "MIT",
+        "count": len(entries),
+        "categories": [
+            {
+                "id": category.slug,
+                "label": category.label,
+                "emoji": category.emoji,
+                "description": category.description,
+                "count": by_category[category.slug],
+            }
+            for category in CATEGORIES
+        ],
+        "servers": entries,
+    }
+
+
+def validate_catalog(catalog: dict) -> None:
+    """Valida il catalogo generato, se jsonschema e' disponibile.
+
+    Il cross-reference tra i due schemi va registrato esplicitamente, perche'
+    catalog.schema.json referenzia server.schema.json per URL e non lo scarica.
+    """
+    try:
+        from jsonschema import Draft202012Validator
+        from referencing import Registry, Resource
+    except ImportError:
+        print(
+            "jsonschema non installato: catalog.json non e' stato validato "
+            "(python3 -m pip install -r scripts/requirements.txt)",
+            file=sys.stderr,
+        )
+        return
+
+    server_schema = json.loads(SERVER_SCHEMA.read_text(encoding="utf-8"))
+    catalog_schema = json.loads(CATALOG_SCHEMA.read_text(encoding="utf-8"))
+    registry = Registry().with_resource(
+        uri=server_schema["$id"], resource=Resource.from_contents(server_schema)
+    )
+
+    validator = Draft202012Validator(catalog_schema, registry=registry)
+    errors = sorted(validator.iter_errors(catalog), key=lambda e: list(e.absolute_path))
+    if errors:
+        for error in errors:
+            location = "".join(f"[{part!r}]" for part in error.absolute_path)
+            print(f"catalog.json: {location or '<root>'}: {error.message}", file=sys.stderr)
+        sys.exit(f"\n{len(errors)} errori nel catalogo generato.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default="site",
+        help="directory di destinazione (default: site)",
+    )
+    args = parser.parse_args()
+
+    output = Path(args.output)
+    if not output.is_absolute():
+        output = ROOT / output
+
+    servers = load_servers()
+    catalog = build_catalog(servers)
+    validate_catalog(catalog)
+
+    if output.exists():
+        shutil.rmtree(output)
+    (output / "schema").mkdir(parents=True)
+
+    (output / "catalog.json").write_text(
+        json.dumps(catalog, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    shutil.copyfile(SERVER_SCHEMA, output / "schema" / "server.schema.json")
+    shutil.copyfile(CATALOG_SCHEMA, output / "schema" / "catalog.schema.json")
+    (output / "index.html").write_text(
+        TEMPLATE_PATH.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    # Evita che GitHub Pages processi i file con Jekyll.
+    (output / ".nojekyll").write_text("", encoding="utf-8")
+
+    print(f"{output.name}/ generato: {catalog['count']} server, versione {CATALOG_VERSION}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -13,19 +13,34 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import NamedTuple
 
 ROOT = Path(__file__).resolve().parent.parent
 SERVERS_DIR = ROOT / "servers"
 README = ROOT / "README.md"
 
-# Ordine, intestazione e descrizione delle categorie ammesse.
+
+class Category(NamedTuple):
+    slug: str
+    emoji: str
+    label: str
+    description: str
+
+    @property
+    def heading(self) -> str:
+        return f"{self.emoji} {self.label}"
+
+
+# Categorie ammesse, nell'ordine in cui compaiono nel README.
+# L'emoji e' separata dalla label perche' serve solo alle intestazioni Markdown:
+# i consumatori di catalog.json ricevono la label pulita.
 CATEGORIES = [
-    ("dati-statistiche", "📊 Dati e Statistiche", "ISTAT, Eurostat, open data"),
-    ("legal-tech", "⚖️ Legal-Tech e Normativa", "Normativa, giurisprudenza, privacy"),
-    ("fatturazione", "🧾 Fatturazione Elettronica", "Fatture elettroniche, SDI"),
-    ("pa-finanza-pubblica", "🏛️ PA, Parlamento e Finanza Pubblica", "PA, parlamento, fisco, appalti"),
-    ("cybersecurity-compliance", "🛡️ Cybersecurity e Compliance", "ACN, AGCM, compliance"),
-    ("design-altro", "🎨 Design e Altro", "Design system, meteo, altro"),
+    Category("dati-statistiche", "📊", "Dati e Statistiche", "ISTAT, Eurostat, open data"),
+    Category("legal-tech", "⚖️", "Legal-Tech e Normativa", "Normativa, giurisprudenza, privacy"),
+    Category("fatturazione", "🧾", "Fatturazione Elettronica", "Fatture elettroniche, SDI"),
+    Category("pa-finanza-pubblica", "🏛️", "PA, Parlamento e Finanza Pubblica", "PA, parlamento, fisco, appalti"),
+    Category("cybersecurity-compliance", "🛡️", "Cybersecurity e Compliance", "ACN, AGCM, compliance"),
+    Category("design-altro", "🎨", "Design e Altro", "Design system, meteo, altro"),
 ]
 
 # Abbreviazioni usate nella colonna "Lang" del catalogo.
@@ -83,19 +98,19 @@ def render_row(server: dict) -> str:
 
 
 def render_catalog(servers: list[dict]) -> str:
-    known = {slug for slug, _, _ in CATEGORIES}
+    known = {category.slug for category in CATEGORIES}
     for server in servers:
         if server.get("category") not in known:
             sys.exit(f"{server['_path']}: categoria sconosciuta {server.get('category')!r}")
 
     sections = []
-    for slug, title, _ in CATEGORIES:
-        rows = sorted((s for s in servers if s["category"] == slug), key=sort_key)
+    for category in CATEGORIES:
+        rows = sorted((s for s in servers if s["category"] == category.slug), key=sort_key)
         if not rows:
             continue
         body = "\n".join(render_row(server) for server in rows)
         sections.append(
-            f"## {title}\n\n"
+            f"## {category.heading}\n\n"
             "| Progetto | ⭐ | Lang | Descrizione |\n"
             "|----------|---:|------|-------------|\n"
             f"{body}"
@@ -142,8 +157,8 @@ def render_badges(servers: list[dict]) -> str:
 
 def render_category_table() -> str:
     lines = ["| Categoria | Descrizione |", "|-----------|-------------|"]
-    for slug, _, description in CATEGORIES:
-        lines.append(f"| `{slug}` | {description} |")
+    for category in CATEGORIES:
+        lines.append(f"| `{category.slug}` | {category.description} |")
     return "\n".join(lines)
 
 

--- a/scripts/templates/index.html
+++ b/scripts/templates/index.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Catalogo dei server MCP italiani</title>
+<meta name="description" content="Catalogo curato dei server Model Context Protocol italiani: dati pubblici, legal-tech, fatturazione elettronica, pubblica amministrazione.">
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #61656b;
+    --line: #d8dbe0;
+    --card: #f7f8fa;
+    --accent: #0b5fff;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg:#0d1117; --fg:#e6edf3; --muted:#8b949e; --line:#272d36; --card:#161b22; --accent:#5b9dff; }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0 auto; padding: 2rem 1.25rem 4rem; max-width: 60rem;
+    background: var(--bg); color: var(--fg);
+    font: 16px/1.55 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  h1 { margin: 0 0 .25rem; font-size: 1.75rem; }
+  .lede { margin: 0 0 1.5rem; color: var(--muted); }
+  a { color: var(--accent); }
+  .api {
+    background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+    padding: .75rem 1rem; margin-bottom: 1.5rem; font-size: .9rem;
+  }
+  .api code { word-break: break-all; }
+  .controls { display: flex; flex-wrap: wrap; gap: .5rem; margin-bottom: 1rem; }
+  input[type=search], select {
+    padding: .5rem .65rem; border: 1px solid var(--line); border-radius: 6px;
+    background: var(--bg); color: var(--fg); font: inherit; font-size: .95rem;
+  }
+  input[type=search] { flex: 1 1 16rem; }
+  #count { color: var(--muted); font-size: .875rem; margin-bottom: 1rem; }
+  ul { list-style: none; margin: 0; padding: 0; }
+  li {
+    border: 1px solid var(--line); border-radius: 8px;
+    padding: .9rem 1rem; margin-bottom: .6rem; background: var(--card);
+  }
+  .row { display: flex; align-items: baseline; gap: .5rem; flex-wrap: wrap; }
+  .name { font-weight: 600; }
+  .meta { color: var(--muted); font-size: .8125rem; }
+  .desc { margin: .35rem 0 .5rem; }
+  .tag {
+    display: inline-block; font-size: .75rem; color: var(--muted);
+    border: 1px solid var(--line); border-radius: 999px;
+    padding: .05rem .5rem; margin: 0 .25rem .25rem 0;
+  }
+  footer { margin-top: 2.5rem; color: var(--muted); font-size: .875rem; }
+</style>
+</head>
+<body>
+<h1>Server MCP italiani</h1>
+<p class="lede">Catalogo curato dei server <a href="https://modelcontextprotocol.io/">Model Context Protocol</a> per il contesto italiano.</p>
+
+<div class="api">
+  Catalogo in JSON: <a href="catalog.json"><code>catalog.json</code></a> —
+  schemi: <a href="schema/catalog.schema.json"><code>catalog</code></a>,
+  <a href="schema/server.schema.json"><code>server</code></a> —
+  sorgente: <a href="https://github.com/bsab/italia-mcp-servers">GitHub</a>
+</div>
+
+<div class="controls">
+  <input type="search" id="q" placeholder="Cerca per nome, descrizione o tag…" autocomplete="off">
+  <select id="category"><option value="">Tutte le categorie</option></select>
+  <select id="language"><option value="">Tutti i linguaggi</option></select>
+</div>
+
+<p id="count">Caricamento…</p>
+<ul id="list"></ul>
+
+<footer>Fatto con ❤️ in Italia — per rendere i dati italiani accessibili all'AI</footer>
+
+<script>
+const el = (id) => document.getElementById(id);
+let servers = [];
+
+const escapeHtml = (value) => String(value).replace(/[&<>"']/g, (c) => (
+  { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+));
+
+function render() {
+  const query = el('q').value.trim().toLowerCase();
+  const category = el('category').value;
+  const language = el('language').value;
+
+  const matches = servers.filter((s) => {
+    if (category && s.category !== category) return false;
+    if (language && s.language !== language) return false;
+    if (!query) return true;
+    const haystack = [s.name, s.description, s.author, ...(s.tags || [])].join(' ').toLowerCase();
+    return haystack.includes(query);
+  });
+
+  el('count').textContent = `${matches.length} server su ${servers.length}`;
+  el('list').innerHTML = matches.map((s) => `
+    <li>
+      <div class="row">
+        <a class="name" href="${escapeHtml(s.url)}">${escapeHtml(s.name)}</a>
+        <span class="meta">${escapeHtml(s.language)} · ★ ${s.stars} · ${escapeHtml(s.license || 'nessuna licenza dichiarata')}</span>
+      </div>
+      <p class="desc">${escapeHtml(s.description)}</p>
+      <div>${(s.tags || []).map((t) => `<span class="tag">${escapeHtml(t)}</span>`).join('')}</div>
+    </li>`).join('');
+}
+
+function fillSelect(select, values) {
+  for (const value of values) {
+    const option = document.createElement('option');
+    option.value = value.id ?? value;
+    option.textContent = value.label ?? value;
+    select.append(option);
+  }
+}
+
+fetch('catalog.json')
+  .then((response) => {
+    if (!response.ok) throw new Error(response.statusText);
+    return response.json();
+  })
+  .then((catalog) => {
+    servers = catalog.servers;
+    fillSelect(el('category'), catalog.categories);
+    fillSelect(el('language'), [...new Set(servers.map((s) => s.language))].sort());
+    for (const id of ['q', 'category', 'language']) el(id).addEventListener('input', render);
+    render();
+  })
+  .catch((error) => {
+    el('count').textContent = `Impossibile caricare il catalogo: ${error.message}`;
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
> Impilata su #7 (base: `bsab-normalize-spdx-licenses`), che a sua volta sta su #6. Da mergiare per ultima.

## Problema

Il catalogo era consumabile solo in due modi, entrambi scomodi: leggere il README in Markdown, o clonare il repository e aprire 30 file separati. Nessun endpoint restituiva l'intero catalogo in una richiesta.

Un catalogo di server MCP — strumenti nati per rendere i dati leggibili dalle macchine — non era esso stesso leggibile dalle macchine.

## Cosa viene pubblicato

`scripts/build_catalog.py` genera `site/` dagli stessi file in `servers/`:

| Risorsa | Contenuto |
|---|---|
| `catalog.json` | Envelope versionato + conteggi per categoria + le 30 voci |
| `schema/catalog.schema.json` | Struttura del catalogo |
| `schema/server.schema.json` | Struttura di una voce |
| `index.html` | Pagina di consultazione con ricerca e filtri, zero dipendenze |

```bash
curl -s https://bsab.github.io/italia-mcp-servers/catalog.json | jq '.servers[].name'
```

Ogni voce include `url`, il link canonico già risolto (`repository_url` → `site_url` → `mcp_endpoint`). Così i consumatori non devono reimplementare il fallback che serve a `cruscotto-italia-mcp`.

## Una sola definizione per due schemi

`catalog.json` aggiunge `url` alle voci, che `server.schema.json` rifiutava per via di `additionalProperties: false`. Invece di duplicare la definizione, ho ristrutturato `server.schema.json` con `$defs/server` + `unevaluatedProperties: false`.

Il comportamento sui file in `servers/` è identico — riverificato che campo extra, categoria inesistente e assenza di URL vengano ancora respinti — ma ora `catalog.schema.json` può riusare la stessa definizione via `$ref` aggiungendo solo `url`.

`build_catalog.py` valida il catalogo che produce, registrando esplicitamente il cross-reference tra i due schemi.

## Refactor di CATEGORIES

`CATEGORIES` era una lista di tuple con l'emoji incollata alla label (`"📊 Dati e Statistiche"`). Accettabile per un heading Markdown, sbagliato in un'API. Ora è un `NamedTuple` con `emoji` e `label` separati: il README compone `heading`, i consumatori ricevono `"Dati e Statistiche"`.

Verificato che il README rigenerato sia **byte-identico** dopo il refactor.

## Versionamento

Una volta pubblicato, l'URL è un'API di fatto. Il campo `version` (attualmente `1`) va incrementato solo per modifiche incompatibili.

## Verifica

Sito servito localmente e aperto nel browser:

- `index.html`, `catalog.json` e i due schemi rispondono 200
- la pagina rende tutte e 30 le voci, con i link corretti
- i tre progetti senza licenza mostrano "nessuna licenza dichiarata" invece di un campo vuoto
- la ricerca funziona: `istat` filtra a 7 risultati su 30
- la validazione del catalogo intercetta campi non previsti e campi obbligatori mancanti

## CI

Il deploy parte su push su `main`. La CI genera e valida il catalogo su **ogni pull request**, in una directory temporanea, così una rottura emerge prima del merge invece che al deploy.

## Nota

Va abilitato Pages nelle impostazioni del repository, con source **GitHub Actions**. `site/` è in `.gitignore`: non viene committato.
