### PR TITLE
feat: added NIS2-public

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/bsab/italia-mcp-servers/actions/workflows/link-check.yml"><img src="https://github.com/bsab/italia-mcp-servers/actions/workflows/link-check.yml/badge.svg" alt="Link check"/></a>
   <a href="https://github.com/bsab/italia-mcp-servers/actions/workflows/pages.yml"><img src="https://github.com/bsab/italia-mcp-servers/actions/workflows/pages.yml/badge.svg" alt="GitHub Pages"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"/></a>
-  <img src="https://img.shields.io/badge/server%20MCP-30-blue.svg" alt="30 server"/>
+  <img src="https://img.shields.io/badge/server%20MCP-31-blue.svg" alt="31 server"/>
   <img src="https://img.shields.io/badge/categorie-6-orange.svg" alt="6 categorie"/>
 <!-- END:badges -->
 </p>
@@ -111,6 +111,7 @@ sono una fotografia indicativa e non rappresentano una valutazione di qualità.
 
 | Progetto | ⭐ | Lang | Descrizione |
 |----------|---:|------|-------------|
+| [NIS2-public](https://github.com/fabriziosalmi/nis2-public) | 28 | Python | Postura e remediation NIS2 per D.Lgs. 138/2024 e ACN |
 | [Italian Competition MCP](https://github.com/Ansvar-Systems/italian-competition-mcp) | 0 | TS | AGCM — decisioni antitrust |
 | [Italian Cybersecurity MCP](https://github.com/Ansvar-Systems/italian-cybersecurity-mcp) | 0 | TS | ACN — linee guida e advisory |
 
@@ -128,11 +129,11 @@ sono una fotografia indicativa e non rappresentano una valutazione di qualità.
 <!-- BEGIN:stats -->
 | Metrica | Valore |
 |---------|--------|
-| Server totali | **30** |
-| Python | 16 |
+| Server totali | **31** |
+| Python | 17 |
 | TypeScript | 13 |
 | JavaScript | 1 |
-| Licenze open source | 27 |
+| Licenze open source | 28 |
 | Senza licenza dichiarata | 3 |
 | Categorie | 6 |
 <!-- END:stats -->

--- a/servers/nis2-public.json
+++ b/servers/nis2-public.json
@@ -1,0 +1,29 @@
+{
+  "name": "NIS2-public",
+  "repository_url": "https://github.com/fabriziosalmi/nis2-public",
+  "site_url": "https://fabriziosalmi.github.io/nis2-public/",
+  "transport": "stdio",
+  "author": "fabriziosalmi",
+  "language": "Python",
+  "license": "AGPL-3.0",
+  "stars": 28,
+  "category": "cybersecurity-compliance",
+  "short_description": "Postura e remediation NIS2 per D.Lgs. 138/2024 e ACN",
+  "description": "Piattaforma self-hosted per postura e remediation NIS2 continua, con governance, scansioni tecniche e moduli per il D.Lgs. 138/2024 e le determine ACN.",
+  "tags": [
+    "nis2",
+    "cybersecurity",
+    "compliance",
+    "acn",
+    "grc",
+    "python"
+  ],
+  "tools": [
+    "check_certificate",
+    "scan_target",
+    "search_playbooks",
+    "get_playbook",
+    "estimate_remediation",
+    "list_governance_items"
+  ]
+}


### PR DESCRIPTION
## Descrizione

Aggiunge NIS2-public al catalogo nella categoria Cybersecurity e Compliance, con metadati verificati, trasporto MCP `stdio` e tool documentati dal progetto.

Il README generato è stato aggiornato a 31 server.

Closes #12