### PR TITLE
Aggiungi i collegamenti Connetti al catalogo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,70 +58,319 @@ cybersecurity e design system.
 
 ## Catalogo
 
-I progetti in **grassetto** sono messi in evidenza dai manutentori. Le stelle
-sono una fotografia indicativa e non rappresentano una valutazione di qualità.
-
 <!-- BEGIN:catalog -->
 ### 📊 Dati e Statistiche
 
-| Progetto | ⭐ | Lang | Descrizione |
-|----------|---:|------|-------------|
-| [**CKAN MCP Server**](https://github.com/ondata/ckan-mcp-server) | 57 | TS | Connettore generico per istanze CKAN (dati.gov.it e portali regionali) |
-| [**ISTAT MCP Server**](https://github.com/ondata/istat_mcp_server) | 23 | Python | Statistiche ISTAT via SDMX API |
-| [ISTAT MCP](https://github.com/SimonBerg255/istat-mcp) | 3 | Python | 4700+ dataset ISTAT via SDMX, senza API key |
-| [ISTAT MCP Server (istatapi)](https://github.com/Halpph/istat-mcp-server) | 2 | Python | Dati statistici ISTAT via libreria Python istatapi |
-| [Italy OpenData MCP](https://github.com/stucchi/italy-opendata-mcp) | 1 | Python | Comuni, province, regioni, CAP, coordinate e codici ISTAT/ANPR |
-| [OpenData AI](https://github.com/agent-engineering-studio/opendata-ai) | 1 | Python | Multi-source: CKAN, ISTAT, Eurostat, OECD |
-| [ISTAT MCP Suite](https://github.com/ManoloZocco/istat-mcp-suite) | 0 | Python | Server unificato per dataset ISTAT |
+<table width="100%">
+  <thead>
+    <tr>
+      <th width="24%">Progetto</th>
+      <th width="8%" align="right">⭐</th>
+      <th width="10%">Lang</th>
+      <th width="46%">Descrizione</th>
+      <th width="12%">Connetti</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><a href="https://github.com/ondata/ckan-mcp-server"><strong>CKAN MCP Server</strong></a></td>
+    <td align="right">57</td>
+    <td>TS</td>
+    <td>Connettore generico per istanze CKAN (dati.gov.it e portali regionali)</td>
+    <td align="center"><a href="https://ckan-mcp-server.andy-pr.workers.dev/mcp"><img src="https://img.shields.io/badge/Connetti-0969da?style=flat-square" alt="Connetti"></a></td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/ondata/istat_mcp_server"><strong>ISTAT MCP Server</strong></a></td>
+    <td align="right">23</td>
+    <td>Python</td>
+    <td>Statistiche ISTAT via SDMX API</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/SimonBerg255/istat-mcp">ISTAT MCP</a></td>
+    <td align="right">3</td>
+    <td>Python</td>
+    <td>4700+ dataset ISTAT via SDMX, senza API key</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/Halpph/istat-mcp-server">ISTAT MCP Server (istatapi)</a></td>
+    <td align="right">2</td>
+    <td>Python</td>
+    <td>Dati statistici ISTAT via libreria Python istatapi</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/stucchi/italy-opendata-mcp">Italy OpenData MCP</a></td>
+    <td align="right">1</td>
+    <td>Python</td>
+    <td>Comuni, province, regioni, CAP, coordinate e codici ISTAT/ANPR</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/agent-engineering-studio/opendata-ai">OpenData AI</a></td>
+    <td align="right">1</td>
+    <td>Python</td>
+    <td>Multi-source: CKAN, ISTAT, Eurostat, OECD</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/ManoloZocco/istat-mcp-suite">ISTAT MCP Suite</a></td>
+    <td align="right">0</td>
+    <td>Python</td>
+    <td>Server unificato per dataset ISTAT</td>
+    <td align="center">—</td>
+  </tr>
+  </tbody>
+</table>
 
 ### ⚖️ Legal-Tech e Normativa
 
-| Progetto | ⭐ | Lang | Descrizione |
-|----------|---:|------|-------------|
-| [**BetterCallClaude Italia**](https://github.com/fedec65/bettercallclaude_italia) | 44 | JS | Quadro normativo italiano completo |
-| [**MCP Legal IT**](https://github.com/capazme/mcp-legal-it) | 14 | Python | 200+ tool: statuti, giurisprudenza, calcoli legali |
-| [Gov IT Legal MCP](https://github.com/SimonBerg255/gov-it-legal-mcp) | 10 | Python | Normattiva + sentenze TAR/CdS |
-| [AnonyMCP](https://github.com/avvocati-e-mac/AnonyMCP) | 5 | TS | Pseudonimizza documenti legali prima dell'LLM |
-| [Italian Law MCP](https://github.com/Ansvar-Systems/italian-law-mcp) | 1 | TS | GDPR, Codice Privacy, cybercrime |
-| [Normattiva MCP](https://github.com/adellorto/normattiva-mcp) | 1 | Python | API di Normattiva |
-| [Normattiva MCP (CLI)](https://github.com/avvocati-e-mac/normattiva-mcp) | 0 | Python | CLI + MCP per citare norme da Normattiva.it |
+<table width="100%">
+  <thead>
+    <tr>
+      <th width="24%">Progetto</th>
+      <th width="8%" align="right">⭐</th>
+      <th width="10%">Lang</th>
+      <th width="46%">Descrizione</th>
+      <th width="12%">Connetti</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><a href="https://github.com/fedec65/bettercallclaude_italia"><strong>BetterCallClaude Italia</strong></a></td>
+    <td align="right">44</td>
+    <td>JS</td>
+    <td>Quadro normativo italiano completo</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/capazme/mcp-legal-it"><strong>MCP Legal IT</strong></a></td>
+    <td align="right">14</td>
+    <td>Python</td>
+    <td>200+ tool: statuti, giurisprudenza, calcoli legali</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/SimonBerg255/gov-it-legal-mcp">Gov IT Legal MCP</a></td>
+    <td align="right">10</td>
+    <td>Python</td>
+    <td>Normattiva + sentenze TAR/CdS</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/avvocati-e-mac/AnonyMCP">AnonyMCP</a></td>
+    <td align="right">5</td>
+    <td>TS</td>
+    <td>Pseudonimizza documenti legali prima dell&#x27;LLM</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/Ansvar-Systems/italian-law-mcp">Italian Law MCP</a></td>
+    <td align="right">1</td>
+    <td>TS</td>
+    <td>GDPR, Codice Privacy, cybercrime</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/adellorto/normattiva-mcp">Normattiva MCP</a></td>
+    <td align="right">1</td>
+    <td>Python</td>
+    <td>API di Normattiva</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/avvocati-e-mac/normattiva-mcp">Normattiva MCP (CLI)</a></td>
+    <td align="right">0</td>
+    <td>Python</td>
+    <td>CLI + MCP per citare norme da Normattiva.it</td>
+    <td align="center">—</td>
+  </tr>
+  </tbody>
+</table>
 
 ### 🧾 Fatturazione Elettronica
 
-| Progetto | ⭐ | Lang | Descrizione |
-|----------|---:|------|-------------|
-| [**Fatture in Cloud MCP**](https://github.com/aringad/fattureincloud-mcp) | 18 | Python | Fatture in Cloud API con Claude AI |
-| [Aruba Fatture MCP](https://github.com/MarckDev/aruba-fatture-mcp) | 3 | TS | Aruba Fatturazione Elettronica + SDI |
-| [MCP Fattura Elettronica IT](https://github.com/cmendezs/mcp-fattura-elettronica-it) | 1 | Python | Validatore e parser XSD per tracciati XML FatturaPA/SDI |
-| [FattureInCloudMCP](https://github.com/badbat75/FattureInCloudMCP) | 0 | TS | Fatture in Cloud API v2, CRUD completo |
+<table width="100%">
+  <thead>
+    <tr>
+      <th width="24%">Progetto</th>
+      <th width="8%" align="right">⭐</th>
+      <th width="10%">Lang</th>
+      <th width="46%">Descrizione</th>
+      <th width="12%">Connetti</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><a href="https://github.com/aringad/fattureincloud-mcp"><strong>Fatture in Cloud MCP</strong></a></td>
+    <td align="right">18</td>
+    <td>Python</td>
+    <td>Fatture in Cloud API con Claude AI</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/MarckDev/aruba-fatture-mcp">Aruba Fatture MCP</a></td>
+    <td align="right">3</td>
+    <td>TS</td>
+    <td>Aruba Fatturazione Elettronica + SDI</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/cmendezs/mcp-fattura-elettronica-it">MCP Fattura Elettronica IT</a></td>
+    <td align="right">1</td>
+    <td>Python</td>
+    <td>Validatore e parser XSD per tracciati XML FatturaPA/SDI</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/badbat75/FattureInCloudMCP">FattureInCloudMCP</a></td>
+    <td align="right">0</td>
+    <td>TS</td>
+    <td>Fatture in Cloud API v2, CRUD completo</td>
+    <td align="center">—</td>
+  </tr>
+  </tbody>
+</table>
 
 ### 🏛️ PA, Parlamento e Finanza Pubblica
 
-| Progetto | ⭐ | Lang | Descrizione |
-|----------|---:|------|-------------|
-| [**DoveVannoINostriSoldi**](https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi) | 258 | TS | Spesa pubblica: SIOPE, debito, PNRR, IRPEF e altro — [endpoint remoto](https://www.dovevannoinostrisoldi.com/api/mcp) |
-| [**Dichiarino MCP**](https://github.com/gsaccardi/dichiarino-mcp) | 23 | Python | Assistente per la dichiarazione dei redditi |
-| [Dati Semantic MCP](https://github.com/italia/dati-semantic-mcp) | 9 | TS | Catalogo semantico Developers Italia, vocabolari e ontologie PA via SPARQL |
-| [ANAC MCP](https://github.com/SimonBerg255/anac-mcp) | 4 | Python | Appalti pubblici ANAC (BDNCP) |
-| [Italian Parliament MCP](https://github.com/ondata/italianparliament-mcp) | 2 | TS | Dati del Parlamento italiano |
-| [RepublicMCP](https://github.com/giuliogarofalo/RepublicMCP) | 1 | TS | Query SPARQL sugli open data di Camera e Senato |
-| [Cruscotto Italia MCP](https://cruscotto-italia-mcp.agid.workers.dev/mcp) | 0 | TS | Dati comunali per codice ISTAT: demografia, SIOPE, PNRR, sanità |
+<table width="100%">
+  <thead>
+    <tr>
+      <th width="24%">Progetto</th>
+      <th width="8%" align="right">⭐</th>
+      <th width="10%">Lang</th>
+      <th width="46%">Descrizione</th>
+      <th width="12%">Connetti</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><a href="https://github.com/Italian-Builders-Org/DoveVannoINostriSoldi"><strong>DoveVannoINostriSoldi</strong></a></td>
+    <td align="right">258</td>
+    <td>TS</td>
+    <td>Spesa pubblica: SIOPE, debito, PNRR, IRPEF e altro</td>
+    <td align="center"><a href="https://www.dovevannoinostrisoldi.com/api/mcp"><img src="https://img.shields.io/badge/Connetti-0969da?style=flat-square" alt="Connetti"></a></td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/gsaccardi/dichiarino-mcp"><strong>Dichiarino MCP</strong></a></td>
+    <td align="right">23</td>
+    <td>Python</td>
+    <td>Assistente per la dichiarazione dei redditi</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/italia/dati-semantic-mcp">Dati Semantic MCP</a></td>
+    <td align="right">9</td>
+    <td>TS</td>
+    <td>Catalogo semantico Developers Italia, vocabolari e ontologie PA via SPARQL</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/SimonBerg255/anac-mcp">ANAC MCP</a></td>
+    <td align="right">4</td>
+    <td>Python</td>
+    <td>Appalti pubblici ANAC (BDNCP)</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/ondata/italianparliament-mcp">Italian Parliament MCP</a></td>
+    <td align="right">2</td>
+    <td>TS</td>
+    <td>Dati del Parlamento italiano</td>
+    <td align="center"><a href="https://italianparliament-mcp.andy-pr.workers.dev/mcp"><img src="https://img.shields.io/badge/Connetti-0969da?style=flat-square" alt="Connetti"></a></td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/giuliogarofalo/RepublicMCP">RepublicMCP</a></td>
+    <td align="right">1</td>
+    <td>TS</td>
+    <td>Query SPARQL sugli open data di Camera e Senato</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://cruscotto-italia-mcp.agid.workers.dev/mcp">Cruscotto Italia MCP</a></td>
+    <td align="right">0</td>
+    <td>TS</td>
+    <td>Dati comunali per codice ISTAT: demografia, SIOPE, PNRR, sanità</td>
+    <td align="center"><a href="https://cruscotto-italia-mcp.agid.workers.dev/mcp"><img src="https://img.shields.io/badge/Connetti-0969da?style=flat-square" alt="Connetti"></a></td>
+  </tr>
+  </tbody>
+</table>
 
 ### 🛡️ Cybersecurity e Compliance
 
-| Progetto | ⭐ | Lang | Descrizione |
-|----------|---:|------|-------------|
-| [NIS2-public](https://github.com/fabriziosalmi/nis2-public) | 28 | Python | Postura e remediation NIS2 per D.Lgs. 138/2024 e ACN |
-| [Italian Competition MCP](https://github.com/Ansvar-Systems/italian-competition-mcp) | 0 | TS | AGCM — decisioni antitrust |
-| [Italian Cybersecurity MCP](https://github.com/Ansvar-Systems/italian-cybersecurity-mcp) | 0 | TS | ACN — linee guida e advisory |
+<table width="100%">
+  <thead>
+    <tr>
+      <th width="24%">Progetto</th>
+      <th width="8%" align="right">⭐</th>
+      <th width="10%">Lang</th>
+      <th width="46%">Descrizione</th>
+      <th width="12%">Connetti</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><a href="https://github.com/fabriziosalmi/nis2-public">NIS2-public</a></td>
+    <td align="right">28</td>
+    <td>Python</td>
+    <td>Postura e remediation NIS2 per D.Lgs. 138/2024 e ACN</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/Ansvar-Systems/italian-competition-mcp">Italian Competition MCP</a></td>
+    <td align="right">0</td>
+    <td>TS</td>
+    <td>AGCM — decisioni antitrust</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/Ansvar-Systems/italian-cybersecurity-mcp">Italian Cybersecurity MCP</a></td>
+    <td align="right">0</td>
+    <td>TS</td>
+    <td>ACN — linee guida e advisory</td>
+    <td align="center">—</td>
+  </tr>
+  </tbody>
+</table>
 
 ### 🎨 Design e Altro
 
-| Progetto | ⭐ | Lang | Descrizione |
-|----------|---:|------|-------------|
-| [Filo — Design System Italia](https://github.com/Fupete/design-system-italia-mcp) | 3 | TS | Design system .italia (sperimentale) |
-| [INGV MCP FDSNWS Event](https://github.com/INGV/mcp-fdsnws-event) | 1 | Python | Dati sismici e eventi in tempo reale via web service INGV |
-| [MCP Meteo Italia](https://github.com/makremriahi99/MCP-Meteo-Italia) | 0 | Python | Meteo in tempo reale con FastMCP + Gradio |
+<table width="100%">
+  <thead>
+    <tr>
+      <th width="24%">Progetto</th>
+      <th width="8%" align="right">⭐</th>
+      <th width="10%">Lang</th>
+      <th width="46%">Descrizione</th>
+      <th width="12%">Connetti</th>
+    </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td><a href="https://github.com/Fupete/design-system-italia-mcp">Filo — Design System Italia</a></td>
+    <td align="right">3</td>
+    <td>TS</td>
+    <td>Design system .italia (sperimentale)</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/INGV/mcp-fdsnws-event">INGV MCP FDSNWS Event</a></td>
+    <td align="right">1</td>
+    <td>Python</td>
+    <td>Dati sismici e eventi in tempo reale via web service INGV</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/makremriahi99/MCP-Meteo-Italia">MCP Meteo Italia</a></td>
+    <td align="right">0</td>
+    <td>Python</td>
+    <td>Meteo in tempo reale con FastMCP + Gradio</td>
+    <td align="center">—</td>
+  </tr>
+  </tbody>
+</table>
 <!-- END:catalog -->
 
 ### Catalogo in numeri

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -9,6 +9,7 @@ Uso:
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import re
 import sys
@@ -76,24 +77,30 @@ def sort_key(server: dict):
     return (not server.get("featured", False), -server.get("stars", 0), server["name"].lower())
 
 
-def escape_cell(text: str) -> str:
-    return text.replace("|", "\\|")
-
-
 def render_row(server: dict) -> str:
-    name = escape_cell(server["name"])
-    label = f"**{name}**" if server.get("featured") else name
-    url = primary_url(server)
-    description = escape_cell(server.get("short_description") or server["description"])
-
+    name = html.escape(server["name"])
+    label = f"<strong>{name}</strong>" if server.get("featured") else name
+    url = html.escape(primary_url(server), quote=True)
+    description = html.escape(server.get("short_description") or server["description"])
     endpoint = server.get("mcp_endpoint")
-    if endpoint and endpoint != url:
-        description += f" — [endpoint remoto]({endpoint})"
-
     language = server.get("language", "—")
+    connect = "—"
+    if endpoint:
+        escaped_endpoint = html.escape(endpoint, quote=True)
+        connect = (
+            f'<a href="{escaped_endpoint}">'
+            '<img src="https://img.shields.io/badge/Connetti-0969da?style=flat-square" '
+            'alt="Connetti"></a>'
+        )
+
     return (
-        f"| [{label}]({url}) | {server.get('stars', 0)} | "
-        f"{escape_cell(LANGUAGE_ABBR.get(language, language))} | {description} |"
+        "  <tr>\n"
+        f'    <td><a href="{url}">{label}</a></td>\n'
+        f'    <td align="right">{server.get("stars", 0)}</td>\n'
+        f"    <td>{html.escape(LANGUAGE_ABBR.get(language, language))}</td>\n"
+        f"    <td>{description}</td>\n"
+        f"    <td align=\"center\">{connect}</td>\n"
+        "  </tr>"
     )
 
 
@@ -111,9 +118,20 @@ def render_catalog(servers: list[dict]) -> str:
         body = "\n".join(render_row(server) for server in rows)
         sections.append(
             f"### {category.heading}\n\n"
-            "| Progetto | ⭐ | Lang | Descrizione |\n"
-            "|----------|---:|------|-------------|\n"
-            f"{body}"
+            '<table width="100%">\n'
+            "  <thead>\n"
+            "    <tr>\n"
+            '      <th width="24%">Progetto</th>\n'
+            '      <th width="8%" align="right">⭐</th>\n'
+            '      <th width="10%">Lang</th>\n'
+            '      <th width="46%">Descrizione</th>\n'
+            '      <th width="12%">Connetti</th>\n'
+            "    </tr>\n"
+            "  </thead>\n"
+            "  <tbody>\n"
+            f"{body}\n"
+            "  </tbody>\n"
+            "</table>"
         )
     return "\n\n".join(sections)
 

--- a/servers/ondata-ckan-mcp-server.json
+++ b/servers/ondata-ckan-mcp-server.json
@@ -1,6 +1,8 @@
 {
   "name": "CKAN MCP Server",
   "repository_url": "https://github.com/ondata/ckan-mcp-server",
+  "mcp_endpoint": "https://ckan-mcp-server.andy-pr.workers.dev/mcp",
+  "transport": "streamable-http",
   "author": "ondata",
   "language": "TypeScript",
   "license": "MIT",
@@ -13,6 +15,7 @@
     "ckan",
     "open-data",
     "dati-gov-it",
-    "portali-regionali"
+    "portali-regionali",
+    "remote-mcp"
   ]
 }

--- a/servers/ondata-italianparliament-mcp.json
+++ b/servers/ondata-italianparliament-mcp.json
@@ -1,6 +1,8 @@
 {
   "name": "Italian Parliament MCP",
   "repository_url": "https://github.com/ondata/italianparliament-mcp",
+  "mcp_endpoint": "https://italianparliament-mcp.andy-pr.workers.dev/mcp",
+  "transport": "streamable-http",
   "author": "ondata",
   "language": "TypeScript",
   "license": "MIT",
@@ -12,6 +14,7 @@
     "parlamento",
     "camera",
     "senato",
-    "typescript"
+    "typescript",
+    "remote-mcp"
   ]
 }


### PR DESCRIPTION
## Descrizione

- aggiunge una colonna **Connetti** alle tabelle del catalogo, con un badge-link solo per i server dotati di `mcp_endpoint`;
- registra gli endpoint remoti di CKAN MCP Server e Italian Parliament MCP, oltre ai due già presenti;
- rende tutte le tabelle delle categorie larghe il 100% con colonne uniformi;
- rimuove la nota sui progetti in grassetto e sulle stelle.

## Checklist

- [x] Ho aggiunto o modificato un file JSON in `servers/` con nome in `kebab-case.json`
- [x] Ho eseguito `python3 scripts/validate_servers.py` e passa
- [x] Ho eseguito `python3 scripts/build_readme.py` e incluso il README aggiornato
- [x] Non ho modificato a mano le tabelle del catalogo, i badge o le statistiche nel README
- [x] Il server implementa il Model Context Protocol ed è pertinente al contesto italiano