### PR TITLE
feat: added Open Parlamento MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/bsab/italia-mcp-servers/actions/workflows/link-check.yml"><img src="https://github.com/bsab/italia-mcp-servers/actions/workflows/link-check.yml/badge.svg" alt="Link check"/></a>
   <a href="https://github.com/bsab/italia-mcp-servers/actions/workflows/pages.yml"><img src="https://github.com/bsab/italia-mcp-servers/actions/workflows/pages.yml/badge.svg" alt="GitHub Pages"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"/></a>
-  <img src="https://img.shields.io/badge/server%20MCP-32-blue.svg" alt="32 server"/>
+  <img src="https://img.shields.io/badge/server%20MCP-33-blue.svg" alt="33 server"/>
   <img src="https://img.shields.io/badge/categorie-6-orange.svg" alt="6 categorie"/>
 <!-- END:badges -->
 </p>
@@ -184,6 +184,13 @@ cybersecurity e design system.
     <td align="right">0</td>
     <td>Python</td>
     <td>CLI + MCP per citare norme da Normattiva.it</td>
+    <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/giuliogarofalo/open-parlamento-mcp">Open Parlamento MCP</a></td>
+    <td align="right">0</td>
+    <td>Python</td>
+    <td>Diritto IT/UE, giurisprudenza, Normattiva, dati pubblici e Parlamento</td>
     <td align="center">—</td>
   </tr>
   </tbody>

--- a/servers/giuliogarofalo-open-parlamento-mcp.json
+++ b/servers/giuliogarofalo-open-parlamento-mcp.json
@@ -1,0 +1,20 @@
+{
+  "name": "Open Parlamento MCP",
+  "repository_url": "https://github.com/giuliogarofalo/open-parlamento-mcp",
+  "author": "giuliogarofalo",
+  "language": "Python",
+  "license": "Apache-2.0",
+  "stars": 0,
+  "category": "legal-tech",
+  "short_description": "Diritto IT/UE, giurisprudenza, Normattiva, dati pubblici e Parlamento",
+  "description": "24 tool su diritto italiano ed europeo, giurisprudenza, relazioni di modifica Normattiva, dati pubblici (CKAN), Eurostat, Parlamento (OpenPolis), PNRR.",
+  "tags": [
+    "diritto",
+    "normattiva",
+    "giurisprudenza",
+    "eurostat",
+    "ckan",
+    "parlamento",
+    "pnrr"
+  ]
+}

--- a/servers/giuliogarofalo-republicmcp.json
+++ b/servers/giuliogarofalo-republicmcp.json
@@ -3,7 +3,7 @@
   "repository_url": "https://github.com/giuliogarofalo/RepublicMCP",
   "author": "giuliogarofalo",
   "language": "TypeScript",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "stars": 1,
   "category": "pa-finanza-pubblica",
   "short_description": "Query SPARQL sugli open data di Camera e Senato",


### PR DESCRIPTION
Aggiunge il mio secondo server MCP al catalogo e corregge un dato non aggiornato sul primo.

- **Nuovo**: `giuliogarofalo-open-parlamento-mcp.json` — Open Parlamento MCP (Python, Apache-2.0, 24 tool: diritto italiano/UE, giurisprudenza Corte Cost./Cassazione/TAR-CdS, relazioni di modifica Normattiva, dati pubblici via CKAN, Eurostat, Parlamento curato via OpenPolis, PNRR). Repo: https://github.com/giuliogarofalo/open-parlamento-mcp
- **Fix**: `giuliogarofalo-republicmcp.json` — licenza aggiornata da MIT ad Apache-2.0 (RepublicMCP è stato rilicenziato).

Validato con `scripts/validate_servers.py` e README rigenerato con `scripts/build_readme.py` come da CONTRIBUTING.md.