### PR TITLE
fix: aggiorna la scheda MCP Fattura Elettronica IT

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ cybersecurity e design system.
     <td><a href="https://github.com/cmendezs/mcp-fattura-elettronica-it">MCP Fattura Elettronica IT</a></td>
     <td align="right">1</td>
     <td>Python</td>
-    <td>Validatore e parser XSD per tracciati XML FatturaPA/SDI</td>
+    <td>FatturaPA: generazione, validazione XSD, firma digitale, invio diretto SDI e supporto alla conservazione</td>
     <td align="center">—</td>
   </tr>
   <tr>

--- a/servers/cmendezs-mcp-fattura-elettronica-it.json
+++ b/servers/cmendezs-mcp-fattura-elettronica-it.json
@@ -6,13 +6,15 @@
   "license": "Apache-2.0",
   "stars": 1,
   "category": "fatturazione",
-  "short_description": "Validatore e parser XSD per tracciati XML FatturaPA/SDI",
-  "description": "Validatore e parser XSD per tracciati XML FatturaPA/SDI (ordinaria e semplificata).",
+  "short_description": "FatturaPA: generazione, validazione XSD, firma digitale, invio diretto SDI e supporto alla conservazione",
+  "description": "Generazione e validazione XSD di fatture FatturaPA B2B, B2G e transfrontaliere, firma XAdES/CAdES, invio diretto a SDI via SDICoop e supporto alla conservazione sostitutiva.",
   "tags": [
     "fattura-elettronica",
     "fatturapa",
     "sdi",
     "xml",
-    "xsd"
+    "xsd",
+    "firma-digitale",
+    "conservazione-sostitutiva"
   ]
 }


### PR DESCRIPTION
## Descrizione

<!-- Cosa cambia questa PR e perché. -->

Closes #19

Il server era già presente nel catalogo, ma la descrizione riportava soltanto validazione e parsing XSD. Aggiorna la voce esistente, senza duplicarla, in base alla [documentazione pubblica](https://github.com/cmendezs/mcp-fattura-elettronica-it):

- Generazione e validazione XSD di fatture FatturaPA B2B, B2G e transfrontaliere.
- Firma digitale XAdES/CAdES e invio diretto a SDI tramite SDICoop.
- Supporto alla conservazione sostitutiva e relativi tag.
- README rigenerato tramite lo script del repository.

La formulazione «supporto alla conservazione» evita di presentare il backend locale di sviluppo come una soluzione a norma pronta per la produzione, per cui il progetto documenta la necessità di un provider.

Verifiche superate: validazione dei 33 server, controllo README, generazione e validazione del catalogo e `git diff --check`.

## Checklist

- [x] Ho aggiunto o modificato un file JSON in `servers/` con nome in `kebab-case.json`
- [x] Ho eseguito `python3 scripts/validate_servers.py` e passa
- [x] Ho eseguito `python3 scripts/build_readme.py` e incluso il README aggiornato
- [x] Non ho modificato a mano le tabelle del catalogo o i badge nel README
- [x] Il server implementa il Model Context Protocol ed è pertinente al contesto italiano

<!--
Se la PR non aggiunge un server (per esempio: correzioni alla documentazione o
agli script), ignora le voci non pertinenti.
-->