### PR TITLE
Rinomina il punteggio in 🎯 Ready score

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ espone la rubrica condivisa.
 
 ## Valutazione statica della documentazione
 
-La **prontezza d'uso documentata** è un indice da 0 a 100, non una misura di
-popolarità, sicurezza o affidabilità runtime. La revisione legge documentazione
+Il **Ready score** è un indice di prontezza d'uso documentata da 0 a 100, non una
+misura di popolarità, sicurezza o affidabilità runtime. La revisione legge documentazione
 pubblica: non esegue server, non chiama tool MCP e non certifica che le istruzioni
 funzionino. Non è un nuovo requisito di ammissione al catalogo.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cybersecurity e design system.
 
 ## Catalogo
 
-La colonna **Prontezza /100** misura la documentazione d'uso, non la popolarità o
+La colonna **🎯 Ready score /100** misura la documentazione d'uso, non la popolarità o
 l'affidabilità runtime. Clicca sul punteggio per consultare criteri, motivazioni,
 fonti e data della revisione. **Non valutato** non significa zero.
 Le voci sono ordinate per punteggio decrescente, poi per nome, con i non valutati
@@ -72,7 +72,7 @@ in fondo; il grassetto indica una scelta editoriale indipendente dal punteggio.
   <thead>
     <tr>
       <th width="23%">Progetto</th>
-      <th width="13%" align="right">Prontezza /100</th>
+      <th width="13%" align="right">🎯 Ready score /100</th>
       <th width="6%" align="right">⭐</th>
       <th width="8%">Lang</th>
       <th width="40%">Descrizione</th>
@@ -145,7 +145,7 @@ in fondo; il grassetto indica una scelta editoriale indipendente dal punteggio.
   <thead>
     <tr>
       <th width="23%">Progetto</th>
-      <th width="13%" align="right">Prontezza /100</th>
+      <th width="13%" align="right">🎯 Ready score /100</th>
       <th width="6%" align="right">⭐</th>
       <th width="8%">Lang</th>
       <th width="40%">Descrizione</th>
@@ -226,7 +226,7 @@ in fondo; il grassetto indica una scelta editoriale indipendente dal punteggio.
   <thead>
     <tr>
       <th width="23%">Progetto</th>
-      <th width="13%" align="right">Prontezza /100</th>
+      <th width="13%" align="right">🎯 Ready score /100</th>
       <th width="6%" align="right">⭐</th>
       <th width="8%">Lang</th>
       <th width="40%">Descrizione</th>
@@ -275,7 +275,7 @@ in fondo; il grassetto indica una scelta editoriale indipendente dal punteggio.
   <thead>
     <tr>
       <th width="23%">Progetto</th>
-      <th width="13%" align="right">Prontezza /100</th>
+      <th width="13%" align="right">🎯 Ready score /100</th>
       <th width="6%" align="right">⭐</th>
       <th width="8%">Lang</th>
       <th width="40%">Descrizione</th>
@@ -348,7 +348,7 @@ in fondo; il grassetto indica una scelta editoriale indipendente dal punteggio.
   <thead>
     <tr>
       <th width="23%">Progetto</th>
-      <th width="13%" align="right">Prontezza /100</th>
+      <th width="13%" align="right">🎯 Ready score /100</th>
       <th width="6%" align="right">⭐</th>
       <th width="8%">Lang</th>
       <th width="40%">Descrizione</th>
@@ -397,7 +397,7 @@ in fondo; il grassetto indica una scelta editoriale indipendente dal punteggio.
   <thead>
     <tr>
       <th width="23%">Progetto</th>
-      <th width="13%" align="right">Prontezza /100</th>
+      <th width="13%" align="right">🎯 Ready score /100</th>
       <th width="6%" align="right">⭐</th>
       <th width="8%">Lang</th>
       <th width="40%">Descrizione</th>
@@ -469,8 +469,9 @@ Per essere incluso, un server deve:
 - fornire almeno un riferimento pubblico tra repository, sito o endpoint MCP;
 - avere documentazione d'uso sufficiente.
 
-### Prontezza d'uso documentata
+### 🎯 Ready score
 
+Il **Ready score** misura la prontezza d'uso documentata, da 0 a 100.
 La rubrica statica v1 valuta le evidenze nella documentazione pubblica:
 
 | Criterio | Peso |

--- a/scripts/build_readme.py
+++ b/scripts/build_readme.py
@@ -133,7 +133,7 @@ def render_catalog(servers: list[dict]) -> str:
             "  <thead>\n"
             "    <tr>\n"
             '      <th width="23%">Progetto</th>\n'
-            '      <th width="13%" align="right">Prontezza /100</th>\n'
+            '      <th width="13%" align="right">🎯 Ready score /100</th>\n'
             '      <th width="6%" align="right">⭐</th>\n'
             '      <th width="8%">Lang</th>\n'
             '      <th width="40%">Descrizione</th>\n'

--- a/scripts/quality.py
+++ b/scripts/quality.py
@@ -1,4 +1,4 @@
-"""Rubrica v1: prontezza d'uso documentata, non affidabilita' runtime."""
+"""Ready score, rubrica v1: prontezza documentata, non affidabilita' runtime."""
 
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ def readiness_label(server: dict) -> str:
 def quality_rubric() -> dict:
     return {
         "version": RUBRIC_VERSION,
-        "name": "Prontezza d’uso documentata",
+        "name": "Ready score",
         "criteria": [
             {"id": key, "label": label, "weight": weight}
             for key, (label, weight) in CRITERIA.items()

--- a/scripts/templates/index.html
+++ b/scripts/templates/index.html
@@ -75,7 +75,7 @@
 </div>
 
 <div class="api">
-  <strong>Prontezza d’uso documentata, non certificazione.</strong>
+  <strong>🎯 Ready score: prontezza d’uso documentata, non certificazione.</strong>
   Il punteggio statico valuta le istruzioni pubbliche: non verifica funzionamento,
   sicurezza o disponibilità. Stelle, accesso remoto e scelte editoriali non danno punti.
   <a href="https://github.com/bsab/italia-mcp-servers/blob/main/CONTRIBUTING.md#valutazione-statica-della-documentazione">Metodo e checklist</a>.
@@ -92,7 +92,7 @@
     <option value="unassessed">Non valutati</option>
   </select>
   <select id="sort" aria-label="Ordinamento">
-    <option value="readiness">Prontezza documentata ↓</option>
+    <option value="readiness">🎯 Ready score ↓</option>
     <option value="name">Nome A–Z</option>
   </select>
 </div>
@@ -127,7 +127,7 @@ function renderQuality(server) {
         <p class="meta">${date}</p></details>` : ''}</div>`;
   }
   return `<div class="quality">
-    <span class="score">Prontezza documentata: ${formatScore(server.readiness_score)}/100</span>
+    <span class="score">🎯 Ready score: ${formatScore(server.readiness_score)}/100</span>
     <span class="meta"> · ${date} · rubrica v${quality.rubric_version}</span>
     <details><summary>Criteri, motivazioni e fonti</summary>
       <ul class="criteria">${rubric.criteria.map((criterion) => {

--- a/scripts/test_quality.py
+++ b/scripts/test_quality.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from jsonschema import Draft202012Validator, FormatChecker
 
 from build_catalog import build_catalog, validate_catalog
-from build_readme import render_row, sort_key
+from build_readme import render_catalog, render_row, sort_key
 from quality import CRITERIA, quality_rubric, readiness_label, readiness_score
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -97,6 +97,13 @@ class QualityTests(unittest.TestCase):
         beta["name"] = "Beta"
         result = sorted([unknown, zero, high, beta], key=sort_key)
         self.assertEqual(result, [beta, high, zero, unknown])
+
+    def test_ready_score_name_and_icon(self):
+        self.assertEqual(quality_rubric()["name"], "Ready score")
+        self.assertIn("🎯 Ready score /100</th>", render_catalog([BASE_SERVER]))
+        template = (ROOT / "scripts/templates/index.html").read_text(encoding="utf-8")
+        self.assertIn('<option value="readiness">🎯 Ready score ↓</option>', template)
+        self.assertIn('<span class="score">🎯 Ready score:', template)
 
     def test_readme_links_to_evidence_and_displays_review_date(self):
         server = assessed("partial")


### PR DESCRIPTION
## Descrizione

<!-- Cosa cambia questa PR e perché. -->

Sostituisce "Prontezza /100" con **🎯 Ready score /100**, un nome più riconoscibile che richiama subito il punteggio, accompagnato dall'icona del bersaglio.

La dicitura è coerente tra README generato, catalogo web e documentazione; il nome della rubrica nell'API diventa "Ready score". Restano invariati criteri, pesi, calcolo, ordinamento e nomi dei campi API. La spiegazione continua a chiarire che lo score valuta la documentazione e non certifica l'affidabilità del server.

Verifiche: 16 test superati, inclusa una regressione su nome e icona; 33 server validati; README rigenerato e allineato; sito e catalogo JSON generati e validati.

## Checklist

- [ ] Ho aggiunto o modificato un file JSON in `servers/` con nome in `kebab-case.json` - N/A
- [x] Ho eseguito `python3 scripts/validate_servers.py` e passa
- [x] Ho eseguito `python3 scripts/build_readme.py` e incluso il README aggiornato
- [x] Non ho modificato a mano le tabelle del catalogo o i badge nel README
- [ ] Il server implementa il Model Context Protocol ed è pertinente al contesto italiano - N/A

<!--
Se la PR non aggiunge un server (per esempio: correzioni alla documentazione o
agli script), ignora le voci non pertinenti.
-->