### PR TITLE
fix: evita falsi positivi nel controllo dei link

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -20,6 +20,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Gli endpoint Streamable HTTP richiedono richieste MCP POST valide e possono
+      # rifiutare GET con 404/405: non sono link web verificabili da Lychee.
+      - name: Escludi gli endpoint MCP dal controllo HTTP generico
+        run: |
+          python3 - <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          endpoints = {
+              json.loads(path.read_text(encoding="utf-8")).get("mcp_endpoint")
+              for path in Path("servers").glob("*.json")
+          }
+          patterns = [f"^{re.escape(url)}$" for url in sorted(endpoints - {None})]
+          Path(".lycheeignore").write_text("\n".join(patterns) + "\n", encoding="utf-8")
+          PY
+
       - name: Controlla i link
         id: lychee
         uses: lycheeverse/lychee-action@v2

--- a/servers/cruscotto-italia-mcp.json
+++ b/servers/cruscotto-italia-mcp.json
@@ -56,8 +56,7 @@
         "status": "partial",
         "evidence": [
           "https://github.com/AgID/cruscotto-italia/blob/6afd864dc1fadd4fe3d47246bd1a1459ddb3e920/README.md#L136-L173",
-          "https://github.com/AgID/cruscotto-italia/blob/6afd864dc1fadd4fe3d47246bd1a1459ddb3e920/frontend/assets/guide/mcp-claude.svg",
-          "https://cruscotto-italia.dati.gov.it/about.html#accesso-mcp"
+          "https://github.com/AgID/cruscotto-italia/blob/6afd864dc1fadd4fe3d47246bd1a1459ddb3e920/frontend/assets/guide/mcp-claude.svg"
         ],
         "notes": "Sono presenti istruzioni concrete per Claude e ChatGPT e un URL MCP remoto. Le pagine consultate non identificano esplicitamente il trasporto MCP come Streamable HTTP o SSE: non lo si ricava dalla sola URL HTTPS né dai metadati del catalogo."
       },


### PR DESCRIPTION
## Descrizione

Il controllo schedulato segnala come non raggiungibili endpoint MCP funzionanti, perché Lychee usa richieste GET mentre gli endpoint Streamable HTTP richiedono richieste MCP POST e possono rispondere con 404 o 405 alle GET.

La workflow ora genera dinamicamente esclusioni esatte per tutti i `mcp_endpoint` del catalogo, continuando a verificare normalmente gli altri URL. Viene inoltre rimossa dalla scheda di Cruscotto Italia un'evidenza non raggiungibile per un certificato TLS non valido.

Verifiche eseguite:
- 33 server validi
- 16 test superati
- README allineato
- Lychee: 512 link validi, 0 errori

Closes #23

## Checklist

- [x] Ho aggiunto o modificato un file JSON in `servers/` con nome in `kebab-case.json`
- [x] Ho eseguito `python3 scripts/validate_servers.py` e passa
- [x] Ho eseguito `python3 scripts/build_readme.py` e incluso il README aggiornato
- [x] Non ho modificato a mano le tabelle del catalogo o i badge nel README
- [x] Il server implementa il Model Context Protocol ed è pertinente al contesto italiano