### PR TITLE
feat: added InvoiceIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/bsab/italia-mcp-servers/actions/workflows/link-check.yml"><img src="https://github.com/bsab/italia-mcp-servers/actions/workflows/link-check.yml/badge.svg" alt="Link check"/></a>
   <a href="https://github.com/bsab/italia-mcp-servers/actions/workflows/pages.yml"><img src="https://github.com/bsab/italia-mcp-servers/actions/workflows/pages.yml/badge.svg" alt="GitHub Pages"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License"/></a>
-  <img src="https://img.shields.io/badge/server%20MCP-33-blue.svg" alt="33 server"/>
+  <img src="https://img.shields.io/badge/server%20MCP-34-blue.svg" alt="34 server"/>
   <img src="https://img.shields.io/badge/categorie-6-orange.svg" alt="6 categorie"/>
 <!-- END:badges -->
 </p>
@@ -265,6 +265,14 @@ in fondo; il grassetto indica una scelta editoriale indipendente dal punteggio.
     <td>TS</td>
     <td>Fatture in Cloud API v2, CRUD completo</td>
     <td align="center">—</td>
+  </tr>
+  <tr>
+    <td><a href="https://invoicein.peculiar.systems/it">InvoiceIn</a></td>
+    <td align="right">Non valutato</td>
+    <td align="right">0</td>
+    <td>Python</td>
+    <td>Fatture passive europee normalizzate in un unico JSON EN 16931, con report di validazione</td>
+    <td align="center"><a href="https://invoicein-api.peculiar.systems/mcp" target="_blank" rel="noopener noreferrer" title="Apri endpoint MCP: InvoiceIn"><kbd>Connetti</kbd></a></td>
   </tr>
   </tbody>
 </table>

--- a/servers/peculiar-systems-invoicein.json
+++ b/servers/peculiar-systems-invoicein.json
@@ -1,0 +1,29 @@
+{
+  "name": "InvoiceIn",
+  "site_url": "https://invoicein.peculiar.systems/it",
+  "mcp_endpoint": "https://invoicein-api.peculiar.systems/mcp",
+  "transport": "streamable-http",
+  "author": "peculiar-systems",
+  "language": "Python",
+  "license": null,
+  "stars": 0,
+  "category": "fatturazione",
+  "short_description": "Fatture passive europee normalizzate in un unico JSON EN 16931, con report di validazione",
+  "description": "Normalizza le fatture ricevute nei diversi formati europei — FatturaPA 1.2, XRechnung, ZUGFeRD/Factur-X, Peppol BIS 3, KSeF — in un unico JSON EN 16931 con report di validazione. Servizio ospitato.",
+  "tags": [
+    "fatturapa",
+    "en-16931",
+    "xrechnung",
+    "factur-x",
+    "peppol",
+    "ksef",
+    "remote-mcp"
+  ],
+  "tools": [
+    "read_invoice",
+    "validate_invoice",
+    "invoice_to_html",
+    "invoice_to_csv",
+    "invoice_to_datev"
+  ]
+}


### PR DESCRIPTION
Grazie per il via libera e per la precisazione: abbiamo rifatto la descrizione partendo da lì.

Abbiamo aggiunto `servers/peculiar-systems-invoicein.json` e rigenerato il README con `build_readme.py`. `validate_servers.py` passa (34 server) e la suite in `scripts/` è verde.

**Natura proprietaria.** La voce non ha `repository_url` e ha `license: null`: il servizio è ospitato da noi e il suo codice non è pubblico. La MIT copre soltanto `peculiar-systems/invoicein-examples` — esempi, collection Postman, manifest MCP e bridge stdio — e il README di quel repository lo dice esplicitamente ("The service itself is not open source"). Se preferisci un marcatore esplicito nello schema invece di `null`, dicci quale e lo adottiamo.

**Quota, limiti, dati.** Senza chiave: 20 fatture al giorno per IP, stesso output. Chiave di prova: 100 fatture, 30 giorni, senza carta. Un credito per fattura e non per chiamata, nessun minimo mensile, file fino a 10 MB. I documenti sono elaborati in memoria e scartati, mai conservati; DPA su richiesta, unico sub-responsabile il provider di hosting. Tutto su <https://invoicein.peculiar.systems/it>.

**On-premise: non è un refuso, è una nostra imprecisione nella issue.** "Docker" compare in tre posti e li avevamo appiattiti in una frase sola:

1. il servizio — parser e validatore — è proprietario e ospitato: nessun pacchetto, nessuna immagine pubblica, nessun codice del server, quindi **non autoinstallabile**, ed è così che va letta la voce;
2. il `Dockerfile` nel repository degli esempi costruisce solo il bridge stdio, che inoltra le chiamate al server ospitato: l'analisi avviene comunque su `invoicein-api.peculiar.systems`;
3. l'immagine on-premise del servizio vero esiste, stessi endpoint e stesso server MCP, fornita su richiesta nell'ambito di un accordo commerciale — per chi non può far uscire le fatture dei fornitori dalla propria rete.

On-premise su richiesta sì, autoinstallabile no. Non si contraddicono, ma nella issue lo avevamo scritto male.

**Sulla precisazione.** Hai ragione che la ricezione da sola aggiunge poco, quindi davanti abbiamo messo la normalizzazione: non "leggere un documento ricevuto", ma restituire lo stesso JSON EN 16931 qualunque sia il formato di partenza — FatturaPA 1.2, XRechnung (UBL e CII), ZUGFeRD/Factur-X, Peppol BIS 3, KSeF FA(2)/FA(3) — così chi integra scrive un parser solo invece di cinque.

**Ready score.** Abbiamo lasciato `quality` assente: la rubrica dice che non è un requisito di ammissione e assegnarci da soli un punteggio ci sembrava improprio. Le fonti per la revisione sono la [server card](https://invoicein-api.peculiar.systems/.well-known/mcp/server-card.json) per transport, autenticazione e tool, i [docs](https://invoicein-api.peculiar.systems/docs) per l'API, la [pagina italiana](https://invoicein.peculiar.systems/it) per quota, limiti e trattamento dati, e gli [esempi](https://github.com/peculiar-systems/invoicein-examples) per bridge, manifest e licenza. L'endpoint risponde senza chiave: i cinque tool si provano subito.
